### PR TITLE
add more details to the spec and address issue #16 #18 #24 #29 #32

### DIFF
--- a/canvas_editContext.html
+++ b/canvas_editContext.html
@@ -30,7 +30,8 @@ To try the "phrase" mode in Japanese IME (on Windows),<br>
 
     let anchorX = 0; // the anchor point of the composition
     let anchorY = 0;
-    let selection = 0; // selection i.e the index of the caret position
+    let selectionStart = 0;
+    let selectionEnd = 0;
 
     function renderCaret(x, y) {
         canvasContext2D.beginPath();
@@ -75,20 +76,22 @@ To try the "phrase" mode in Japanese IME (on Windows),<br>
         // rener texts in EditContext's buffer
         canvasContext2D.strokeText(editContext.text, anchorX, anchorY);
 
-        let caretX = anchorX + selection * charWidth;
-        let caretY = anchorY;
-        renderCaret(caretX, caretY);
+        if (selectionStart == selectionEnd) {
+            // if collpased selection, render the caret and update bounds for the caret.
+            let caretIndex = selectionStart;
+            let caretX = anchorX + caretIndex * charWidth;
+            let caretY = anchorY;
+            renderCaret(caretX, caretY);
 
-        // update layout info through EditContext so IME can show candidate window in the correct position.
+            let selectionBound = computeCharacterBound(caretIndex);
+            selectionBound.width = 1; // 1px caret
+            editContext.updateSelectionBounds(selectionBound);
+        } else {
+            // TODO: render the selection and update the selection bounds
+        }
+
         let controlBound = canvas.getBoundingClientRect();
-        selectoinClientX = caretX + canvas.offsetLeft;
-        selectoinClientY = caretY + canvas.offsetTop;
-        let selectionBound = DOMRect.fromRect({x:selectoinClientX, y:selectoinClientY, width:1, height:10});
-
-        controlBound = scaleDOMRect(controlBound, window.devicePixelRatio);
-        selectionBound = scaleDOMRect(selectionBound, window.devicePixelRatio);
-
-        editContext.updateBounds(controlBound, selectionBound);
+        editContext.updateControlBounds(controlBound);
     }
 
     // when EditContext is active (i.e. the associated element is focused)
@@ -96,7 +99,8 @@ To try the "phrase" mode in Japanese IME (on Windows),<br>
     editContext.addEventListener("textupdate", e => {
         console.log(`editcontext.text:[${editContext.text}]`);
         console.log(`textupdate:[${e.updateText}], composition range (${e.updateRangeStart}, ${e.updateRangeEnd}), selection (${e.newSelectionStart}, ${e.newSelectionEnd})`);
-        selection = e.newSelectionStart;
+        selectionStart = e.newSelectionStart;
+        selectionEnd = e.newSelectionEnd;
         render();
     });
 
@@ -118,7 +122,6 @@ To try the "phrase" mode in Japanese IME (on Windows),<br>
             let charBounds = [];
             for (offset = rangeStart; offset < rangeEnd; offset++) {
                 let bound = computeCharacterBound(offset);
-                bound = scaleDOMRect(bound, window.devicePixelRatio);
                 charBounds.push(bound);
             }
             editContext.updateCharacterBounds(rangeStart, charBounds);
@@ -151,13 +154,4 @@ To try the "phrase" mode in Japanese IME (on Windows),<br>
         anchorY = event.pageY - elemTop;
         render();
     });
-
-    // To handle zoom levels
-    function scaleDOMRect(rect, scale) {
-        rect.x = rect.x * scale;
-        rect.y = rect.y * scale;
-        rect.width = rect.width * scale;
-        rect.height = rect.height * scale;
-        return rect;
-    }
 </script>

--- a/index.html
+++ b/index.html
@@ -89,52 +89,45 @@
         </section>
         <section id="editcontext-model">
             <h3>The EditContext Model</h3>
-            <section id="text-input-abstractions">
-                <h3>Text Input Abstractions</h3>
-                <div class="note">
-                    <p>
-                        The [=Text Input Service=] and [=Text Edit Context=] are abstractions representing the common aspects of text input across many operating systems. 
-                        Because {{EditContext}} is a primitive API designed to integrate with these various text input implementations, this spec will first define the [=Text Input Service=] and [=Text Edit Context=] abstractions, and then define how the {{EditContext}} is used by authors to interact with those abstractions.
-                        This specification does not define how a user agent should construct such abstractions.
-                    </p>
-                </div>
-                <p>The [=Text Edit Context=] has a [=TEC text=] array, a [=TEC selection start=] index, a [=TEC selection end=] index, a [=TEC composition start=] index, a [=TEC composition end=] index, a [=TEC is composing=] flag, a [=TEC control bounds=], a [=TEC selection bounds=], and a [=TEC array of character location data=].</p>
-                <p>The <dfn>TEC text</dfn> is a UTF-16 encoded string of code points representing editable content. The initial value is the empty string.</p>
-                <p>The <dfn>TEC selection start</dfn> index identifies the offset of the selection's starting position within [=TEC text=]. The value must be between 0 and the length of [=TEC text=] (inclusive). The initial value is 0.</p>
-                <p>The <dfn>selection end</dfn> position is the end position of the current selection. The initial value is 0.</p>
-                <p>The <dfn>composition start</dfn> position is the start of the current composition. The initial value is 0</p>
-                <p>The <dfn>composition end</dfn> position is the end of the current composition. The initial value is 0</p>
-                <p>The <dfn>is composing</dfn> flag indicates if there is an active composition. The initial value is false</p>
-                <p>The <dfn>control bounds</dfn> is the bounding box of the display surface. It is in the [=client coordinate=] and the initial x, y, width, and height are 0, 0, 0, and 0, respectively.</p>
-                <p>The <dfn>selection bounds</dfn> is the bounding box of the selection. It is in the [=client coordinate=] and the initial x, y, width, and height are 0, 0, 0, 0, respectively.</p>
-                <p>The <dfn>array of character bounds</dfn> consists of the bounding boxes of the rendering result of the characters in a substring of [=text=]. These bounding boxes are used by the [=Text Input Method=] to properly position its user interface. The bounding boxes are in [=client coordinate=] and the array is initially empty.</p>    
-            </section>
+            <p>
+                The [=Text Input Service=] and [=Text Edit Context=] are abstractions representing the common aspects of text input across many operating systems.
+                An {{EditContext}} is a JavaScript reflection of the [=Text Edit Context=]. 
+                When changes are made to the [=Text Edit Context=] by the [=Text Input Service=], those changes are reflected to the author asynchronously in the form of events which are dispatched against the [=active EditContext=].
+                When the author makes changes to the [=active EditContext=], those changes will be reflected in the [=Text Edit Context=] during the next lifecycle update.
+            </p>
+            <p>
+                To reflect changes made by the author to the [=active EditContext=] since the last lifecycle update, run the steps to [=update the Text Edit Context=].
+            </p>
+            <p>
+                When the [=Text Input Service=] updates the state of the [=Text Edit Context=], run the steps to [=update the EditContext=].
+            </p>
+            <p>
+                Both the [=Text Edit Context=] and {{EditContext}} have a [=text state=]. The <dfn>text state</dfn> consists of:
+            </p>
+            <ul>
+                <li><dfn>text</dfn> which is a {{DOMString}} representing editable content. The initial value is the empty string.</li>
+                <li><dfn>selection start</dfn> which refers to the offset in [=text=] where the selection starts. The initial value is 0.</li>
+                <li><dfn>selection end</dfn> which refers to the offset in [=text=] where the selection ends. The initial value is 0. [=selection end=] must always be greater than or equal to [=selection start=].</li>
+                <li><dfn>is composing</dfn> which indicates if there is an active composition. The initial value is false.</li>
+                <li><dfn>composition start</dfn> which refers to the offset in [=text=] representing the start position of the text being actively composed. The initial value is 0.</p></li>
+                <li><dfn>composition end</dfn> which refers to the offset in [=text=] representing the end position of the text being actively composed. The initial value is 0. [=composition end=] must always be greater than or equal to [=composition start=].</li>
+                <li><dfn>control bounds</dfn> is a rectangle describing the area of the screen in which [=text=] is displayed.  It is in the [=client coordinate=] system and the initial x, y, width, and height all 0.</li>
+                <li><dfn>selection bounds</dfn> is the rectangle describing the position of selection. It is in the [=client coordinate=] system and the initial x, y, width, and height are all 0.</li>
+                <li><dfn>codepoint locations</dfn> which is an array of [=codepoint location=]. The array is initially empty.</li>
+            </ul>
+            <p><dfn>codepoint location</dfn> is a struct that captures the location (in [=client coordinate=]s) of codepoints from [=text=].  Each struct represents a contigious run of codepoints starting at a specified offset.  The struct contains:</p>
+            <ul>
+                <li><dfn>start index</dfn> which is an offset into [=text=] that respresents the position before the first codepoint whose location is reported by the first member of [=codepoint rects=] array.</li>
+                <li><dfn>codepoint rects</dfn> is an array of {{DOMRect}} defining the bounding box of each codepoint.</li>
+            </ul>
+            <p>In addition to [=text state=], an {{EditContext}} also has:
+            <ul>
+                <li><dfn>dirty flag</dfn> which is initially false, but set true by any steps which allow the author to update the state of the {{EditContext}}.</li>
+            </ul>
+            <p>Associating an {{EditContext}} to an element makes that element eligible to become an [=editing host=].  An <dfn>editing host</dfn> is as an [=editable element=], but whose parent is not an [=editable element=].</p>
+            <p>A user agent should have at most one <dfn>active EditContext</dfn>.  An {{EditContext}} is active when its associated element, or a descendant of its associated element for which it is the [=editing host=], is the [=active element=] in a [=fully active document=].</p>
+            <p>When an {{EditContext}} meets the criteria above, it must be made the [=active EditContext=] by running the steps to [=activate an EditContext=].</p>
             
-            
-            
-            <p>An {{EditContext}} is a JavaScript projection of the [=Text Edit Context=]. Changes made to the [=Text Edit Context=] by the [=Text Input Service=] are communicated to the author in the form of events dispatched against it's associated {{EditContext}}.</p>
-            
-            
-
-            <p></p>
-            <p>An {{EditContext}} has a [=text=], a [=selection start=] position, a [=selection end=] position, a [=composition start=] position,  a [=composition end=] position, a [=is composing=] flag, a [=control bounds=], a [=selection bounds=], an [=array of character bounds=] and a [=character bounds range start=] index.
-            <p>The <dfn>text</dfn> consists of the plain text of the editable content. The initial value is the empty string.</p>
-            <p>The <dfn>selection start</dfn> position is the start position of the current selection. The initial value is 0.</p>
-            <p>The <dfn>selection end</dfn> position is the end position of the current selection. The initial value is 0.</p>
-            <p>The <dfn>composition start</dfn> position is the start of the current composition. The initial value is 0</p>
-            <p>The <dfn>composition end</dfn> position is the end of the current composition. The initial value is 0</p>
-            <p>The <dfn>is composing</dfn> flag indicates if there is an active composition. The initial value is false</p>
-            <p>The <dfn>control bounds</dfn> is the bounding box of the display surface. It is in the [=client coordinate=] and the initial x, y, width, and height are 0, 0, 0, and 0, respectively.</p>
-            <p>The <dfn>selection bounds</dfn> is the bounding box of the selection. It is in the [=client coordinate=] and the initial x, y, width, and height are 0, 0, 0, 0, respectively.</p>
-            <p>The <dfn>array of character bounds</dfn> consists of the bounding boxes of the rendering result of the characters in a substring of [=text=]. These bounding boxes are used by the [=Text Input Method=] to properly position its user interface. The bounding boxes are in [=client coordinate=] and the array is initially empty.</p>
-            <p>The <dfn>character bounds range start</dfn> index is the index in the [=text=] for the first character of the [=array of character bounds=]. The inital value is 0.</p>
-
-            <p>Associating an {{EditContext}} to an element makes that element intrinsically [=focusable=].  When the element is focused, the user agent will use the state of the {{EditContext}} to construct a [=Text Edit Context=] that is provided to the [=Text Input Service=] of the OS:</p>
-            <ol>
-              <li>Instead of deriving the text content of the [=Text Edit Context=] from the DOM, it will be taken from the {{EditContext}}'s [=text=].</li>
-              <li>Instead of deriving the location of selection within that text from the document’s selection, the user agent will use the {{EditContext}}'s [=selection start=] and [=selection end=].</li>
-              <li>Instead of querying the DOM’s associated CSS boxes for the size and position of selection, character bounds, and the editable region of the document, the user agent will use the {{EditContext}}'s [=selection bounds=], [=array of character bounds=], and [=control bounds=] respectively.</li>
-            </ol>
 
             <p>Using an {{EditContext}}, an author can mark a region of the document [=editable=] by associating an {{EditContext}} object with an element as shown in the example below: </p>
             <aside class="example" title="Associate an EditContext with an Element">

--- a/index.html
+++ b/index.html
@@ -438,7 +438,7 @@
     <section id="conformance">
         <p>
           This specification defines conformance criteria that apply to a single
-          product: the <dfn id="dfn-user-agent">user agent</dfn> that implements the interfaces that
+          product: the user agent that implements the interfaces that
           it contains.
         </p>
         <p>
@@ -506,7 +506,7 @@
                     <dl>
                         <dt>Input</dt>
                         <dd>|newText|, a string</dd>
-                        <dd>|textSpans|, a structure that has text format info</dd>
+                        <dd>|textFormats|, a structure that has an array of text format info from the [=Text Input Service=]</dd>
                         <dd>|newSelectionStart|, the new position for the start of the selection</dd>
                         <dd>|newSelectionEnd|, the new position for the end of the selection</dd>
                         <dt>Output</dt>
@@ -541,7 +541,7 @@
                 <li>Set [=selection end=] to |newSelectionEnd|</li>
                 <li>[=Dispatch text update event=] with |newText|</li>
                 <li>Set [=composition end=] to [=composition start=] plus the length of |newText|</li>
-                <li>[=Dispatch text format update event=] with |textSpans|</li>
+                <li>[=Dispatch text format update event=] with |textFormats|</li>
                 <li>[=Dispatch character bound update event=]</li>
             </ol>
             </div><!-- algorithm -->
@@ -585,13 +585,30 @@
     <div class="algorithm">
         <dl>
             <dt>Input</dt>
-            <dd>|textSpans|, a structure that has text format info</dd>
+            <dd>|textFormats|, a structure that has an array of text format info from the [=Text Input Service=]</dd>
             <dt>Output</dt>
             <dd>None</dd>
         </dl>
 <ol>
     <li>
-        Let |event| be a new {{TextFormatUpdateEvent}} with |textSpans|
+        Let |formats| be an array of {{TextFormat}}, initially empty.
+    </li>
+    <li>
+        For each text format in |textFormats|,
+        <ol>
+            <li>Set |rangeStart| be the start index of the range where the format will be applied to.</li>
+            <li>Set |rangeEnd| be the end index of the range</li>
+            <li>Set |textColor| be the color of the text. The value is a <a href="https://www.w3.org/TR/css-color-4/#serializing-sRGB-values">serialized sRGB values</a>.</li>
+            <li>Set |backgroundColor| be the color of the background. The value is a <a href="https://www.w3.org/TR/css-color-4/#serializing-sRGB-values">serialized sRGB values</a>.</li>
+            <li>Set |underlineStyle| be the underline style. The value is one of the following strings: "None", "Solid", "Dotted", "Dashed", and "Wavy". </li>
+            <li>Set |underlineThickness| be the underline thickness. The value is one of the following strings: "None", "Thin", and "Thick"</li>
+            <li>Set |underlineColor| be the underline color. The value is a <a href="https://www.w3.org/TR/css-color-4/#serializing-sRGB-values">serialized sRGB values</a>.</li>
+            <li>Let |textFormat| be a {{TextFormat}} with |rangeStart|, |rangeEnd|, |textColor|, |backgroundColor|, |underlineStyle|, |underlineThickness|, and |underlineColor|.</li>
+            <li>Add |textFormat| to |formats|</li>
+        </ol>
+    </li>
+    <li>
+        Let |event| be a new {{TextFormatUpdateEvent}} with |formats|
     </li>
     <li> [=Fire an event=] named "textformateupdate" with |event|</li>
 </ol>
@@ -1070,7 +1087,7 @@ interface TextFormatUpdateEvent : Event {
                 </dd>
                 <dt>{{TextFormat/underlineStyle}}, of type {{DOMString}}, readonly
                 </dt>
-                <dd>The style of the underline. The value is one of the following strings: "None", "Solid", "Dotted", "Dashed", and "Squiggle".
+                <dd>The style of the underline. The value is one of the following strings: "None", "Solid", "Dotted", "Dashed", and "Wavy".
                 </dd>
                 <dt>{{TextFormat/underlineThickness}}, of type {{DOMString}}, readonly
                 </dt>

--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@
                 When the [=Text Input Service=] updates the state of the [=Text Edit Context=], run the steps to [=update the EditContext=].
             </p>
             <p>
-                Both the [=Text Edit Context=] and {{EditContext}} have a [=text state=]. The <dfn>text state</dfn> consists of:
+                Both the [=Text Edit Context=] and {{EditContext}} have a [=text state=] which holds the information exchanged in the aforementioned updates. The <dfn>text state</dfn> consists of:
             </p>
             <ul>
                 <li><dfn>text</dfn> which is a {{DOMString}} representing editable content. The initial value is the empty string.</li>
@@ -125,12 +125,13 @@
                 <li><dfn>dirty flag</dfn> which is initially false, but set true by any steps which allow the author to update the state of the {{EditContext}}.</li>
             </ul>
             <p>
-                Associating an {{EditContext}} to an element makes that element an [=editing host=].  An <dfn>editing host</dfn> is as an [=editable element=] which serves as the target for input events.  
+                Associating an {{EditContext}} to an element makes that element an [=editing host=].  An <dfn>editing host</dfn> is an [=editable element=] which serves as the target for input events.  
                 Prior to the existence of {{EditContext}}, an [=editing host=] was limited to [=editable element=]s whose parents are not [=editable element=]s.
                 With the introduction of {{EditContext}}, the definition is expanded to include any element associated with an {{EditContext}}.
             </p>
             <p>A user agent should have at most one <dfn>active EditContext</dfn>.  An {{EditContext}} is active when its associated element, or a descendant of its associated element for which it is the [=editing host=], is the [=active element=] in a [=fully active document=].</p>
             <p>When an {{EditContext}} meets the criteria above, it must be made the [=active EditContext=] by running the steps to [=activate an EditContext=].</p>
+            <p>If an element associated with an [=active EditContext=] no longer meets the criteria outlined above, run the steps to [=deactivate an EditContext=].</p>
             
 
             <p>Using an {{EditContext}}, an author can mark a region of the document [=editable=] by associating an {{EditContext}} object with an element as shown in the example below: </p>

--- a/index.html
+++ b/index.html
@@ -90,13 +90,19 @@
         <section id="editcontext-model">
             <h3>The EditContext Model</h3>
             
-            <p>An <dfn>edit context</dfn> is a conceptual object that can be used by the user agent to contruct a [=Text Edit Context=] for the [=Text Input Service=] of the OS.</p>
-            
-            <p>An [=edit context=] has a <dfn>text</dfn> that consists of the plain text of the editable content, a <dfn>selection range</dfn> that marks the start and the end of the current selection, a <dfn>composition range</dfn> that marks the start and the end of the current composition, <dfn>control bounds</dfn> that indicates the bounding box of the display surface, <dfn>selection bounds</dfn> that indicates the bounding box of the selection, <dfn>character bounds</dfn> that indicates the bounding boxes of an array of characters of which the bounding boxes are needed for the [=Text Input Service=] of the OS, and a <dfn>character bounds range start</dfn> index that indicates the index of the first character that is used for the [=character bounds=].
-            
-            <p>An {{EditContext}} is a JavaScript projection of [=edit context=]. Using an {{EditContext}}, an author can mark a region of the document editable by associating an instance of an {{EditContext}} with an element.</p>
-            
-            <p>Associating an {{EditContext}} to an element makes that element intrinsically [=focusable=].  When the element is focused, the user agent will use the state of the [=edit context=] to construct a [=Text Edit Context=] that is provided to the [=Text Input Service=] of the OS:</p>
+            <p>An {{EditContext}} has a [=text=], a [=selection start=] position, a [=selection end=] position, a [=composition start=] position,  a [=composition end=] position, a [=is composing=] flag, a [=control bounds=], a [=selection bounds=], an [=array of character bounds=] and a [=character bounds range start=] index.
+            <p>The <dfn>text</dfn> consists of the plain text of the editable content. The initial value is the empty string.</p>
+            <p>The <dfn>selection start</dfn> position is the start position of the current selection. The initial value is 0.</p>
+            <p>The <dfn>selection end</dfn> position is the end position of the current selection. The initial value is 0.</p>
+            <p>The <dfn>composition start</dfn> position is the start of the current composition. The initial value is 0</p>
+            <p>The <dfn>composition end</dfn> position is the end of the current composition. The initial value is 0</p>
+            <p>The <dfn>is composing</dfn> flag indicates if there is an active composition. The initial value is false</p>
+            <p>The <dfn>control bounds</dfn> is the bounding box of the display surface. It is in the [=client coordinate=] and the initial x, y, width, and height are 0, 0, 0, and 0, respectively.</p>
+            <p>The <dfn>selection bounds</dfn> is the bounding box of the selection. It is in the [=client coordinate=] and the initial x, y, width, and height are 0, 0, 0, 0, respectively.</p>
+            <p>The <dfn>array of character bounds</dfn> consists of the bounding boxes of the rendering result of the characters in a substring of [=text=]. These bounding boxes are used by the [=Text Input Method=] to properly position its user interface. The bounding boxes are in [=client coordinate=] and the array is initially empty.</p>
+            <p>The <dfn>character bounds range start</dfn> index is the index in the [=text=] for the first character of the [=array of character bounds=]. The inital value is 0.</p>
+
+            <p>Associating an {{EditContext}} to an element makes that element intrinsically [=focusable=].  When the element is focused, the user agent will use the state of the {{EditContext}} to construct a [=Text Edit Context=] that is provided to the [=Text Input Service=] of the OS:</p>
             <ol>
               <li>Instead of deriving the text content of the [=Text Edit Context=] from the DOM, it will be taken from [=edit context=]'s [=text=].</li>
               <li>Instead of deriving the location of selection within that text from the document’s selection, the user agent will use [=edit context=]'s [=selection range=].</li>
@@ -456,58 +462,239 @@
                };
             </pre>
             <dl>
-                <dt>editContext, of type {{EditContext}}</dt>
-                <dd>initially null. The {{HTMLElement/editContext}} getter steps are to return [=this=]'s [=edit context=].</dd>
+                <dt>editContext</dt>
+                <dd>Initially null. The {{HTMLElement/editContext}} getter steps are to return [=this=]'s {{EditContext}} if there is an {{EditContext}} associated.</dd>
+                <dd>The {{HTMLElement/editContext}} setter must follow these steps:
+                    <div class="algorithm">
+                        <dl>
+                            <dt>Input</dt>
+                            <dd>|editContext|</dd>
+                            <dt>Output</dt>
+                            <dd>None</dd>
+                        </dl>
+                    <ol>
+                    <li>If |editContext| is null
+                        <ol>
+                            <li>run [=Detach EditContext=]</li>
+                        </ol>
+                    </li>
+                    <li>Else
+                        <ol>
+                            <li>run [=Attach EditContext=]</li>
+                        </ol>
+                    </li>                    
+                    </ol>
+                    </div><!-- algorithm -->                    
             </dl>
    
-            <p>When an element is associated with an {{EditContext}}, it is focusable regardless of whether its [=contentediable=] attribute is true or not.</p>
+            <p>When an element is associated with an {{EditContext}}, it is [=editable=] regardless of whether its [=contentediable=] attribute is true or not.</p>
     
-            <p>An element's [=edit context=] is [=activated=] when the element is focused and deactivated when the associated element is blurred.</p>
+            <p>An element's {{EditContext}} is [=activated=] when the element is [=focused=], and deactivated when the associated element is [=blurred=].</p>
     
-            <p>When an [=edit context=] is activated, the user agent MUST NOT modify the DOM when there is [=user text input=], instead, below steps should be implemented:</p>
-    
-            <p>If in a [=composition=]: </p>
+            <p>When an {{EditContext}} is [=activated=], the user agent must not modify the DOM when there is user text input from the [=Text Input Service=], instead, the user agent must run [=Update the composition=] if the text input is a composition, and [=Update the text=] if the text input is not a composition.</p>
+
+            <p>When an {{EditContext}} is [=activated=], the user agent must [=Update Text Input Service=] with the current state of the activated {{EditContext}} at least once every frame.</p>
+
+            <p>When an {{EditContext}} is [=activated=], the user agent must [=Modify BeforeInput Event=]'s behavior and must not fire any [=InputEvent=] when there is user text input from the [=Text Input Service=].</p>
+
+            <p>When an element with an associated {{EditContext}} is connected to the tree, the user agent must run [=Connect Element=].</p>
+
+            <p>When an element with an associated {{EditContext}} is disconnected from the tree, the user agent must run [=Disconnect Element=].</p>
+
+                <h4><dfn>Update the composition</dfn></h4>
+                <div class="algorithm">
+                    <dl>
+                        <dt>Input</dt>
+                        <dd>|newText|, a string</dd>
+                        <dd>|textSpans|, a structure that has text format info</dd>
+                        <dd>|newSelectionStart|, the new position for the start of the selection</dd>
+                        <dd>|newSelectionEnd|, the new position for the end of the selection</dd>
+                        <dt>Output</dt>
+                        <dd>None</dd>
+                    </dl>
             <ol>
                 <li>
-                    [=Fire an event=] named "beforeinput", if applicable to the user text input, at the focused element. If the beforeinput event is cancelled, abort these steps.
+                    If |newText| is not empty and [=is composing=] is false
+                    <ol>
+                        <li>[=Fire an event=] named "compositionstart" at the activated {{EditContext}}.
+                        </li>
+                        <li>set [=is composing=] to true</li>
+                    </ol>
                 </li>
                 <li>
-                    Update [=text=], [=selection range=], [=composition range=] of the activated [=edit context=] according to the [=Text Input Service=] of the OS.
+                    If |newText| is empty and [=is composing=] is false
+                    <ol>
+                        <li>Return</li>
+                    </ol>
                 </li>
                 <li>
-                    [=Fire an event=] named "compositionstart" at the activated [=edit context=] if it's a [=start of a composition=].
+                    If [=composition start=] is 0 and [=composition end=] is 0
+                    <ol>
+                        <li>Set [=composition start=] to |newSelectionStart|</li>
+                        <li>Set [=composition end=] to |newSelectionEnd|</li>
+                    </ol>
                 </li>
                 <li>
-                    [=Fire an event=] named "textupdate" at the activated [=edit context=].
+                    Replace the substring of [=text=] in the range of [=composition start=] and [=composition end=] with |newText|
                 </li>
-                <li>
-                    [=Fire an event=] named "textformateupdate" at the activated [=edit context=].
-                </li>
-                <li>
-                    [=Fire an event=] named "characterboundsupdate" at the activated [=edit context=].
-                </li>
-                <li>
-                    [=Fire an event=] named "compositionend" at the activated [=edit context=] if it's an [=end of a composition=].
-                </li>
+                <li>Set [=selection start=] to |newSelectionStart|</li>
+                <li>Set [=selection end=] to |newSelectionEnd|</li>
+                <li>[=Dispatch text update event=] with |newText|</li>
+                <li>Set [=composition end=] to [=composition start=] plus the length of |newText|</li>
+                <li>[=Dispatch text format update event=] with |textSpans|</li>
+                <li>[=Dispatch character bound update event=]</li>
             </ol>
-            <p>If not in a composition: </p>
-            <ol>
-                <li>
-                    [=Fire an event=] named "beforeinput", if applicable to the user text input, at the focused element. If the beforeinput event is cancelled, abort these steps.
-                </li>
-                <li>
-                    Update [=text=], [=selection range=] of the activated [=edit context=] according to the user text input.
-                </li>
-                <li>
-                    [=Fire an event=] named "textupdate" at the activated EditContext.
-                </li>
-                <li>
-                    [=Fire an event=] named "characterboundsupdate" at the activated EditContext.
-                </li>
-            </ol>
-            <p>
-                An [=edit context=] can be associated with multiple elements but only the element that has focus will receive beforeinput events.
-            </p>
+            </div><!-- algorithm -->
+
+            <h4><dfn>Update the text</dfn></h4>
+            <div class="algorithm">
+                <dl>
+                    <dt>Input</dt>
+                    <dd>|newText|, a string</dd>
+                    <dt>Output</dt>
+                    <dd>None</dd>
+                </dl>
+
+                <ol>
+                    <li>
+                        Replace the substring of [=text=] in the range of [=selection start=] and [=selection end=] with |newText|
+                    </li>
+                    <li>Set [=selection start=] to [=selection start=] plus the length of |newText|</li>
+                    <li>Set [=selection end=] to [=selection start=]</li>
+                    <li>[=Dispatch text update event=] with |newText|</li>
+                </ol>
+            </div>
+
+            <h4><dfn>Dispatch text update event</dfn></h4>
+        <div class="algorithm">
+            <dl>
+                <dt>Input</dt>
+                <dd>|newText|, a string</dd>
+                <dt>Output</dt>
+                <dd>None</dd>
+            </dl>
+    <ol>
+        <li>
+            Let |event| be a new {{TextUpdateEvent}} with |newText|, [=composition start=], [=composition end=], [=selection start=], and [=selection end=]
+        </li>
+        <li> [=Fire an event=] named "textupdate" with |event|</li>
+    </ol>
+    </div><!-- algorithm -->
+
+    <h4><dfn>Dispatch text format update event</dfn></h4>
+    <div class="algorithm">
+        <dl>
+            <dt>Input</dt>
+            <dd>|textSpans|, a structure that has text format info</dd>
+            <dt>Output</dt>
+            <dd>None</dd>
+        </dl>
+<ol>
+    <li>
+        Let |event| be a new {{TextFormatUpdateEvent}} with |textSpans|
+    </li>
+    <li> [=Fire an event=] named "textformateupdate" with |event|</li>
+</ol>
+</div><!-- algorithm -->
+
+<h4><dfn>Dispatch character bound update event</dfn></h4>
+<div class="algorithm">
+    <dl>
+        <dt>Input</dt>
+        <dd>None</dd>
+        <dt>Output</dt>
+        <dd>None</dd>
+    </dl>
+<ol>
+<li>
+    Let |event| be a new {{CharacterBoundsUpdateEvent}} with [=composition start=] and [=composition end=]
+</li>
+<li> [=Fire an event=] named "characterboundsupdate" with |event|</li>
+</ol>
+</div><!-- algorithm -->
+<h4><dfn>Update Text Input Service</dfn></h4>
+<div class="algorithm">
+    <dl>
+        <dt>Input</dt>
+        <dd>None</dd>
+        <dt>Output</dt>
+        <dd>None</dd>
+    </dl>
+<ol>
+<li>
+    <div class="note">Add details</div>
+</li>
+</ol>
+</div><!-- algorithm -->
+<h4><dfn>Modify BeforeInput Event</dfn></h4>
+<div class="algorithm">
+    <dl>
+        <dt>Input</dt>
+        <dd>None</dd>
+        <dt>Output</dt>
+        <dd>None</dd>
+    </dl>
+<ol>
+<li>
+    <div class="note">Add details</div>
+</li>
+</ol>
+</div><!-- algorithm -->
+
+<h4><dfn>focused</dfn></h4>
+<div class="algorithm">
+<ol>
+<li>
+    <div class="note">Add details</div>
+</li>
+</ol>
+</div><!-- algorithm -->
+
+<h4><dfn>blurred</dfn></h4>
+<div class="algorithm">
+<ol>
+<li>
+    <div class="note">Add details</div>
+</li>
+</ol>
+</div><!-- algorithm -->
+
+<h4><dfn>Connect Element</dfn></h4>
+<div class="algorithm">
+<ol>
+<li>
+    <div class="note">Add details</div>
+</li>
+</ol>
+</div><!-- algorithm -->
+
+<h4><dfn>Disconnect Element</dfn></h4>
+<div class="algorithm">
+<ol>
+<li>
+    <div class="note">Add details</div>
+</li>
+</ol>
+</div><!-- algorithm -->
+
+<h4><dfn>Attach EditContext</dfn></h4>
+<div class="algorithm">
+<ol>
+<li>
+    <div class="note">Add details</div>
+</li>
+</ol>
+</div><!-- algorithm -->
+
+<h4><dfn>Detach EditContext</dfn></h4>
+<div class="algorithm">
+<ol>
+<li>
+    <div class="note">Add details</div>
+</li>
+</ol>
+</div><!-- algorithm -->
+
         </section>
         <h3 id="editcontext-interface">EditContext Interface</h3>
     <pre class="idl"><xmp>dictionary EditContextInit {
@@ -534,7 +721,7 @@ interface EditContext : EventTarget {
     readonly attribute unsigned long selectionEnd;
     readonly attribute unsigned long compositionRangeStart;
     readonly attribute unsigned long compositionRangeEnd;
-    readonly attribute boolean isInComposition;
+    readonly attribute boolean isComposing;
     readonly attribute DOMRect controlBounds;
     readonly attribute DOMRect selectionBounds;
     readonly attribute unsigned long characterBoundsRangeStart;
@@ -548,120 +735,165 @@ interface EditContext : EventTarget {
 };</xmp></pre>
         <dl>
             <dt>text</dt>
-            <dd>The {{EditContext/text}} getter steps are to return [=this=]'s [=edit context=]'s [=text=].</dd>
+            <dd>The {{EditContext/text}} getter steps are to return [=this=]'s [=text=].</dd>
 
             <dt>selectionStart</dt>
-            <dd>The {{EditContext/selectionStart}} getter steps are to return the index of the start of [=this=]'s [=edit context=]'s [=selection range=].</dd>
+            <dd>The {{EditContext/selectionStart}} getter steps are to return [=this=]'s [=selection start=].</dd>
 
             <dt>selectionEnd</dt>
-            <dd>The {{EditContext/selectionEnd}} getter steps are to return the index of the end of [=this=]'s [=edit context=]'s [=selection range=].</dd>
+            <dd>The {{EditContext/selectionEnd}} getter steps are to return [=this=]'s [=selection end=].</dd>
 
             <dt>compositionRangeStart</dt>
-            <dd>The {{EditContext/compositionRangeStart}} getter steps are to return the index of the start of [=this=]'s [=edit context=]'s [=composition range=].</dd>
+            <dd>The {{EditContext/compositionRangeStart}} getter steps are to return [=this=]'s [=composition start=].</dd>
 
             <dt>compositionRangeEnd</dt>
-            <dd>The {{EditContext/compositionRangeEnd}} getter steps are to return the index of the end of [=this=]'s [=edit context=]'s [=composition range=].</dd>
+            <dd>The {{EditContext/compositionRangeEnd}} getter steps are to return [=this=]'s [=composition end=].</dd>
 
-            <dt>isInComposition</dt>
-            <dd>The {{EditContext/isInComposition}} getter steps are to return there is an active composition.</dd>
+            <dt>isComposing</dt>
+            <dd>The {{EditContext/isComposing}} getter steps are to return [=this=]'s [=is composing=].</dd>
 
             <dt>controlBounds</dt>
-            <dd>The {{EditContext/compositionRangeEnd}} getter steps are to return [=this=]'s [=edit context=]'s [=control bounds=].</dd>
+            <dd>The {{EditContext/controlBounds}} getter steps are to return [=this=]'s [=control bounds=].</dd>
 
 <p class="note">
     The control bound may be used by the OS for hittesting to trigger the virtual keyboard.
 </p>
 
             <dt>selectionBounds</dt>
-            <dd>The {{EditContext/selectionBounds}} getter steps are to return [=this=]'s [=edit context=]'s [=selection bounds=].</dd>
+            <dd>The {{EditContext/selectionBounds}} getter steps are to return [=this=]'s [=selection bounds=].</dd>
 
             <dt>characterBounds</dt>
-            <dd>The {{EditContext/characterBounds}} getter steps are to return [=this=]'s [=edit context=]'s [=character bounds=].</dd>
+            <dd>The {{EditContext/characterBounds}} getter steps are to return [=this=]'s [=array of character bounds=].</dd>
 
             <dt>characterBoundsRangeStart</dt>
-            <dd>The {{EditContext/characterBoundsRangeStart}} getter steps are to return [=this=]'s [=character bounds range start=]'s [=character bounds=].</dd>
+            <dd>The {{EditContext/characterBoundsRangeStart}} getter steps are to return [=this=]'s [=character bounds range start=].</dd>
 
+            <dt>updateText() method</dt>
+            <dd>
+              <p>
+                The method must follow these steps:
+              </p>
+              <div class="algorithm">
+                <dl>
+                    <dt>Input</dt>
+                    <dd>|rangeStart|, an unsigned long</dd>
+                    <dd>|rangeEnd|, an unsigned long</dd>
+                    <dd>|newText|, a DOMString</dd>
+                    <dt>Output</dt>
+                    <dd>None</dd>
+                </dl>
+                <ol>
+                    <li>
+                        If [=this=] is not activated, abort these steps.
+                    </li>
+                    <li>
+                        Replace the substring of [=text=] in the range of |rangeStart| and |rangeEnd| with |newText|
+                    </li>
+                    <li>
+                        <div class="note">Add details regarding rangeStart/rangeEnd vs. [=selection start=]/[=selection end=]</div>
+                    </li>
+                </ol>
+            </div>
+            </dd>
             <dt>updateSelection() method</dt>
             <dd>
                 <p>
                   The method must follow these steps:
                 </p>
-                <ol>
-                  <li>
-                    If the EditContext is not activated, abort these steps.
-                  </li>
-                  <li>
-                    If start > end, abort these steps.
-                  </li>
-                  <li>
-                    set the start of the [=selection range=] to <i>start</i>
-                  </li>
-                  <li>
-                    set the end of the [=selection range=] to <i>end</i>
-                  </li>
-                </ol>
+                <div class="algorithm">
+                    <dl>
+                        <dt>Input</dt>
+                        <dd>|start|, an unsigned long</dd>
+                        <dd>|end|, an unsigned long</dd>
+                        <dt>Output</dt>
+                        <dd>None</dd>
+                    </dl>
+                    <ol>
+                        <li>
+                            If [=this=] is not activated, abort these steps.
+                        </li>
+                        <li>
+                            If |start| > |end|, abort these steps.
+                        </li>
+                        <li>
+                            set [=selection start=] to |start|
+                        </li>
+                        <li>
+                            set [=selection end=] to |end|
+                        </li>
+                    </ol>
+                </div>
             </dd>
             <dt>updateSelectionBounds() method</dt>
               <dd>
                 <p>
                   The method must follow these steps:
                 </p>
-                <ol>
-                  <li>
-                    If the [=edit context=] is not activated, abort these steps.
-                  </li>
-                  <li>
-                    set [=selection bounds=] to <i>selectoinBound</i>.
-                  </li>
-                </ol>
+                <div class="algorithm">
+                    <dl>
+                        <dt>Input</dt>
+                        <dd>|selectionBounds|, a [=DOMRect=]</dd>
+                        <dt>Output</dt>
+                        <dd>None</dd>
+                    </dl>
+                    <ol>
+                        <li>
+                            If [=this=] is not activated, abort these steps.
+                        </li>
+                        <li>
+                            set [=selection bounds=] to |selectionBounds|
+                        </li>
+                    </ol>
+                </div>
               </dd>
               <dt>updateControlBounds() method</dt>
               <dd>
                 <p>
                   The method must follow these steps:
                 </p>
-                <ol>
-                  <li>
-                    If the [=edit context=] is not activated, abort these steps.
-                  </li>
-                  <li>
-                    set [=control bounds=] to <i>controlBounds</i>.
-                  </li>
-                </ol>
+                <div class="algorithm">
+                    <dl>
+                        <dt>Input</dt>
+                        <dd>|controlBounds|, a [=DOMRect=]</dd>
+                        <dt>Output</dt>
+                        <dd>None</dd>
+                    </dl>
+                    <ol>
+                        <li>
+                            If [=this=] is not activated, abort these steps.
+                        </li>
+                        <li>
+                            set [=control bounds=] to |controlBounds|
+                        </li>
+                    </ol>
+                </div>
               </dd>
               <dt>updateCharacterBounds() method</dt>
               <dd>
                 <p>
                   The method must follow these steps:
                 </p>
-                <ol>
-                  <li>
-                    If the EditContext is not activated, abort these steps.
-                  </li>
-                  <li>
-                    Set the [=character bounds range start=] index to <i>rangeStart</i>.
-                  </li>
-                  <li>
-                    Set [=character bounds=] to <i>characterBounds</i>.
-                  </li>
-                </ol>
+                <div class="algorithm">
+                    <dl>
+                        <dt>Input</dt>
+                        <dd>|rangeStart|, an unsigned long</dd>
+                        <dd>|characterBounds|, an array of [=DOMRect=]</dd>
+                        <dt>Output</dt>
+                        <dd>None</dd>
+                    </dl>
+                    <ol>
+                        <li>
+                            If [=this=] is not activated, abort these steps.
+                        </li>
+                        <li>
+                            set [=character bounds range start=] to |rangeStart|.
+                        </li>
+                        <li>
+                            set [=control bounds=] to |controlBounds|.
+                        </li>
+                    </ol>
+                </div>
               </dd>
-
-            <dt>updateText() method</dt>
-              <dd>
-                <p>
-                  The method must follow these steps:
-                </p>
-                <ol>
-                  <li>
-                    If the EditContext is not activated, abort these steps.
-                  </li>
-                  <li>
-                    Replace the string in the range of <i>rangeStart</i> and <i>rangeEnd</i> of {{EditContext/text}} with <i>text</i>.
-                  </li>
-                </ol>
-              </dd>
-
             <dt>attachedElements() method</dt>
             <dd><p>The method returns elements that are associated with the EditContext.</p></dd>
             <p class="issue">

--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@
             </p>
             <p>
                 To reflect changes made by the author to the [=active EditContext=] since the last lifecycle update, run the steps to [=update the Text Edit Context=] 
-                with the [=active EditContext=]'s [=text state=]'s [=text=], [=select start=], [=select end=], [=control bounds=], [=selection bounds=], and [=codepoint locations=].
+                with the [=active EditContext=]'s [=text state=]'s [=text=], [=selection start=], [=selection end=], [=control bounds=], [=selection bounds=], and [=codepoint locations=].
             </p>
             <p>
                 When the [=Text Input Service=] updates the state of the [=Text Edit Context=], run the steps to [=update the EditContext=] 
@@ -144,8 +144,8 @@
                 <li><dfn>character bounds updated flag</dfn> which is initially false.</li>
             </ul>
             <p>
-                Associating an {{EditContext}} to an element makes that element an [=editing host=].  An [=editing host=] is an [=editable element=] which serves as the target for input events.  
-                Prior to the existence of {{EditContext}}, an [=editing host=] was limited to [=editable element=]s whose parents are not [=editable element=]s.
+                Associating an {{EditContext}} to an element makes that element an [=editing host=].  An [=editing host=] is an editable element which serves as the target for input events.  
+                Prior to the existence of {{EditContext}}, an [=editing host=] was limited to editable elements whose parents are not editable elements.
                 With the introduction of {{EditContext}}, the definition is expanded to include any element associated with an {{EditContext}}.
             </p>
             <p class="note">
@@ -161,7 +161,7 @@
             <p>When there is an [=active EditContext=] and there is a text input from the [=Text Input Service=], the user agent must run [=Update the EditContext=].</p>
 
 
-            <p>Using an {{EditContext}}, an author can mark a region of the document [=editable=] by associating an {{EditContext}} object with an element as shown in the example below: </p>
+            <p>Using an {{EditContext}}, an author can mark a region of the document editable by associating an {{EditContext}} object with an element as shown in the example below: </p>
             <aside class="example" title="Associate an EditContext with an Element">
                 <pre><xmp><script type="module"> 
     let canvas = document.querySelector("canvas") 
@@ -779,10 +779,10 @@ interface EditContext : EventTarget {
             <dd>The {{EditContext/selectionBounds}} getter steps are to return [=this=]'s [=selection bounds=].</dd>
 
             <dt>characterBounds</dt>
-            <dd>The {{EditContext/characterBounds}} getter steps are to return [=this=]'s [=array of character bounds=].</dd>
+            <dd>The {{EditContext/characterBounds}} getter steps are to return [=this=]'s [=codepoint rects=].</dd>
 
             <dt>characterBoundsRangeStart</dt>
-            <dd>The {{EditContext/characterBoundsRangeStart}} getter steps are to return [=this=]'s [=character bounds range start=].</dd>
+            <dd>The {{EditContext/characterBoundsRangeStart}} getter steps are to return [=this=]'s [=start index=].</dd>
 
             <dt>updateText() method</dt>
             <dd>
@@ -848,7 +848,7 @@ interface EditContext : EventTarget {
                 <div class="algorithm">
                     <dl>
                         <dt>Input</dt>
-                        <dd>|selectionBounds|, a [=DOMRect=]</dd>
+                        <dd>|selectionBounds|, a {{DOMRect}}</dd>
                         <dt>Output</dt>
                         <dd>None</dd>
                     </dl>
@@ -870,7 +870,7 @@ interface EditContext : EventTarget {
                 <div class="algorithm">
                     <dl>
                         <dt>Input</dt>
-                        <dd>|controlBounds|, a [=DOMRect=]</dd>
+                        <dd>|controlBounds|, a {{DOMRect}}</dd>
                         <dt>Output</dt>
                         <dd>None</dd>
                     </dl>
@@ -893,7 +893,7 @@ interface EditContext : EventTarget {
                     <dl>
                         <dt>Input</dt>
                         <dd>|rangeStart|, an unsigned long</dd>
-                        <dd>|characterBounds|, an array of [=DOMRect=]</dd>
+                        <dd>|characterBounds|, an array of {{DOMRect}}</dd>
                         <dt>Output</dt>
                         <dd>None</dd>
                     </dl>
@@ -902,10 +902,10 @@ interface EditContext : EventTarget {
                             If [=this=] is not activated, abort these steps.
                         </li>
                         <li>
-                            set [=character bounds range start=] to |rangeStart|.
+                            set [=start index=] to |rangeStart|.
                         </li>
                         <li>
-                            set [=control bounds=] to |controlBounds|.
+                            set [=codepoint rects=] to |controlBounds|.
                         </li>
                     </ol>
                 </div>

--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
                 <figcaption>A sequence diagram illustrating a typical flow for text input.</figcaption>
             </figure>
             <p>Existing user agents handle the details of this text input process so that the author’s responsibility ends at declaring what elements of the document represent an editable region.  Authors express which regions are editable using input elements, textarea elements, contenteditable elements, or by setting the designMode attribute to true to mark an entire document as editable. </p>
-            <p>As an editable region of the document is focused, the user agent automatically produces the [=Text Edit Context=] from the contents of the editable region and the position of the selection within it.  When a [=Text Input Method=] produces text, the user agent translates the events against its [=Text Edit Context=] into a set of DOM and style modifications – only some of which are described using existing events that an author can handle. </p>
+            <p>As an editable region of the document is <a href="https://html.spec.whatwg.org/multipage/interaction.html#focused">focused</a>, the user agent automatically produces the [=Text Edit Context=] from the contents of the editable region and the position of the selection within it.  When a [=Text Input Method=] produces text, the user agent translates the events against its [=Text Edit Context=] into a set of DOM and style modifications – only some of which are described using existing events that an author can handle. </p>
             <p>Authors that want to produce sophisticated editing experiences may be challenged by the current approach.  If, for example, the text and selection are rendered to a canvas, user agents are unable to produce a [=Text Edit Context=] to drive the text input process.  Authors compensate by resorting to offscreen editable elements, but this approach comes with negative implications for accessibility, it deteriorates the input experience, and requires complex code to synchronize the position of the text in the offscreen editable element with the corresponding text in the canvas. </p>
             <p>With the introduction of this EditContext API, authors can more directly participate in the protocol for text input and avoid the pitfalls described above.</p>
         </section>
@@ -139,7 +139,7 @@
                 [=Editing host=] may not be the best term to use to describe the impact of associating an {{EditContext}} with an {{HTMLElement}}.
                 It has similarities, such as making the {{HTMLElement}} the target for input events, but also differences in that the content of the [=editing host=] is not changed as a result of that input.
             </p>
-            <p>A user agent should have at most one <dfn>active EditContext</dfn>.  An {{EditContext}} is active when its associated element, or a descendant of its associated element is [=focused=].</p>
+            <p>A user agent should have at most one <dfn>active EditContext</dfn>.  An {{EditContext}} is active when its associated element, or a descendant of its associated element is <a href="https://html.spec.whatwg.org/multipage/interaction.html#focused">focused</a>.</p>
             <p>When an {{EditContext}} meets the criteria above, it must be made the [=active EditContext=] by running the steps to [=activate an EditContext=].</p>
             <p>If an element associated with an [=active EditContext=] no longer meets the criteria outlined above, run the steps to [=deactivate an EditContext=].</p>
             
@@ -524,7 +524,7 @@
    
             <p>When an element is associated with an {{EditContext}}, it is [=editable=] regardless of whether its [=contentediable=] attribute is true or not.</p>
     
-            <p>An element's {{EditContext}} is [=activated=] when the element is [=focused=], and deactivated when the associated element is [=blurred=].</p>
+            <p>An element's {{EditContext}} is [=activated=] when the element is <a href="https://html.spec.whatwg.org/multipage/interaction.html#focused">focused</a>, and deactivated when the associated element is [=blurred=].</p>
     
             <p>When an {{EditContext}} is [=activated=], the user agent must not modify the DOM when there is user text input from the [=Text Input Service=], instead, the user agent must run [=Update the composition=] if the text input is a composition, and [=Update the text=] if the text input is not a composition.</p>
 

--- a/index.html
+++ b/index.html
@@ -530,7 +530,7 @@
 
             <p>When an {{EditContext}} is [=activated=], the user agent must [=Update Text Input Service=] with the current state of the activated {{EditContext}} at least once every frame.</p>
 
-            <p>When an {{EditContext}} is [=activated=], the user agent must [=Modify BeforeInput Event=]'s behavior and must not fire any [=InputEvent=] when there is user text input from the [=Text Input Service=].</p>
+            <p>When an {{EditContext}} is [=activated=] and there is user text input from the [=Text Input Service=], the user agent must [=Modify BeforeInput Event=]'s behavior and must not fire any [=InputEvent=].</p>
 
             <p>When an element with an associated {{EditContext}} is connected to the tree, the user agent must run [=Connect Element=].</p>
 
@@ -577,7 +577,7 @@
                 <li>[=Dispatch text update event=] with |newText|</li>
                 <li>Set [=composition end=] to [=composition start=] plus the length of |newText|</li>
                 <li>[=Dispatch text format update event=] with |textFormats|</li>
-                <li>[=Dispatch character bound update event=]</li>
+                <li>[=Dispatch character bounds update event=]</li>
             </ol>
             </div><!-- algorithm -->
 
@@ -635,21 +635,18 @@
             <li>Set |rangeEnd| be the end index of the range</li>
             <li>Set |textColor| be the color of the text. The value is a <a href="https://www.w3.org/TR/css-color-4/#serializing-sRGB-values">serialized sRGB values</a>.</li>
             <li>Set |backgroundColor| be the color of the background. The value is a <a href="https://www.w3.org/TR/css-color-4/#serializing-sRGB-values">serialized sRGB values</a>.</li>
-            <li>Set |underlineStyle| be the underline style. The value is one of the following strings: "None", "Solid", "Dotted", "Dashed", and "Wavy". </li>
-            <li>Set |underlineThickness| be the underline thickness. The value is one of the following strings: "None", "Thin", and "Thick"</li>
+            <li>Set |underlineStyle| be the underline style. The value is one of the following strings: "none", "solid", "double", "dotted", "dashed", and "wavy". </li>
+            <li>Set |underlineThickness| be the underline thickness. The value is one of the following strings: "none", "thin", and "thick"</li>
             <li>Set |underlineColor| be the underline color. The value is a <a href="https://www.w3.org/TR/css-color-4/#serializing-sRGB-values">serialized sRGB values</a>.</li>
             <li>Let |textFormat| be a {{TextFormat}} with |rangeStart|, |rangeEnd|, |textColor|, |backgroundColor|, |underlineStyle|, |underlineThickness|, and |underlineColor|.</li>
             <li>Add |textFormat| to |formats|</li>
         </ol>
     </li>
-    <li>
-        Let |event| be a new {{TextFormatUpdateEvent}} with |formats|
-    </li>
-    <li> [=Fire an event=] named "textformateupdate" with |event|</li>
+    <li> [=Fire an event=] named "textformateupdate" at the activated EditContext using {{TextFormatUpdateEvent}} with |formats|</li>
 </ol>
 </div><!-- algorithm -->
 
-<h4><dfn>Dispatch character bound update event</dfn></h4>
+<h4><dfn>Dispatch character bounds update event</dfn></h4>
 <div class="algorithm">
     <dl>
         <dt>Input</dt>

--- a/index.html
+++ b/index.html
@@ -631,17 +631,28 @@
 </div><!-- algorithm -->
 <h4><dfn>Update Text Input Service</dfn></h4>
 <div class="algorithm">
+    <div class="note">
+        <p>Some platform implementations require that the [=Text Edit Context=] be able to supply
+        data about its content synchronously.  This is challenging since the most up-to-date data
+        is typically held in JavaScript data structures maintained by the author, and input threads
+        used for text input should generally not be blocked on JavaScript processing.</p>
+        <p>To avoid a blocking implementation, the data required by the [=Text Edit Context=] is stored
+        in the {{EditContext}} by the author.  With each frame, the web platform must copy the
+        contents of the {{EditContext}} to the [=Text Edit Context=].  When the platform's [=Text Input Service=]
+        queries the [=Text Edit Context=], the data used to answer the query will be only a frame behind.</p>
+        <p>The algorithm below captures the steps to copy that data.</p>
+    </div>
     <dl>
         <dt>Input</dt>
         <dd>None</dd>
         <dt>Output</dt>
         <dd>None</dd>
     </dl>
-<ol>
-<li>
-    <div class="note">Add details</div>
-</li>
-</ol>
+    <ol>
+        <li>
+            <div class="note">Add details</div>
+        </li>
+    </ol>
 </div><!-- algorithm -->
 <h4><dfn>Modify BeforeInput Event</dfn></h4>
 <div class="algorithm">

--- a/index.html
+++ b/index.html
@@ -95,10 +95,12 @@
                 When the author makes changes to the [=active EditContext=], those changes will be reflected in the [=Text Edit Context=] during the next lifecycle update.
             </p>
             <p>
-                To reflect changes made by the author to the [=active EditContext=] since the last lifecycle update, run the steps to [=update the Text Edit Context=].
+                To reflect changes made by the author to the [=active EditContext=] since the last lifecycle update, run the steps to [=update the Text Edit Context=] 
+                with the [=active EditContext=]'s [=text state=]'s [=text=], [=select start=], [=select end=], [=control bounds=], [=selection bounds=], and [=codepoint locations=].
             </p>
             <p>
-                When the [=Text Input Service=] updates the state of the [=Text Edit Context=], run the steps to [=update the EditContext=].
+                When the [=Text Input Service=] updates the state of the [=Text Edit Context=], run the steps to [=update the EditContext=] 
+                with the [=Text Edit Context=]'s [=text state=]'s [=text=], [=text formats=], [=selection start=], [=selection end=], [=is composing=], [=composition start=], and [=composition end=].
             </p>
             <p>
                 Both the [=Text Edit Context=] and {{EditContext}} have a [=text state=] which holds the information exchanged in the aforementioned updates. The <dfn>text state</dfn> consists of:
@@ -110,9 +112,20 @@
                 <li><dfn>is composing</dfn> which indicates if there is an active composition. The initial value is false.</li>
                 <li><dfn>composition start</dfn> which refers to the offset in [=text=] representing the start position of the text being actively composed. The initial value is 0.</p></li>
                 <li><dfn>composition end</dfn> which refers to the offset in [=text=] representing the end position of the text being actively composed. The initial value is 0. [=composition end=] must always be greater than or equal to [=composition start=].</li>
+                <li><dfn>text formats</dfn> which is an array of [=text format=]. The array is initially empty.</li>
                 <li><dfn>control bounds</dfn> is a rectangle describing the area of the screen in which [=text=] is displayed.  It is in the [=client coordinate=] system and the initial x, y, width, and height all 0.</li>
                 <li><dfn>selection bounds</dfn> is the rectangle describing the position of selection. It is in the [=client coordinate=] system and the initial x, y, width, and height are all 0.</li>
                 <li><dfn>codepoint locations</dfn> which is an array of [=codepoint location=]. The array is initially empty.</li>
+            </ul>
+            <p><dfn>text format</dfn> is a struct that indicates decorative properties that should be applied to the ranges of [=text=].  The struct contains:</p>
+            <ul>
+                <li><dfn>rangeStart</dfn> which is an offset into [=text=] that respresents the position before the first codepoint that should be decorated.</li>
+                <li><dfn>rangeEnd</dfn> which is an offset into [=text=] that respresents the position after the last codepoint that should be decorated.</li>
+                <li><dfn>textColor</dfn> which is the prefered color of the decorated [=text=] range. The value is a <a href="https://www.w3.org/TR/css-color-4/#serializing-sRGB-values">serialized sRGB values</a>.</li>
+                <li><dfn>backgroundColor</dfn> which is the prefered background color of the decorated [=text=] range. The value is a <a href="https://www.w3.org/TR/css-color-4/#serializing-sRGB-values">serialized sRGB values</a>.</li>
+                <li><dfn>underlineStyle</dfn> which is the prefered underline style of the decorated [=text=] range. The value is one of the following strings: "none", "solid", "double", "dotted", "dashed", and "wavy". </li>
+                <li><dfn>underlineThickness</dfn> which is the prefered underline thickness of the decorated [=text=] range. The value is one of the following strings: "none", "thin", and "thick"</li>
+                <li><dfn>underlineColor</dfn> which is the prefered underline color of the decorated [=text=] range. The value is a <a href="https://www.w3.org/TR/css-color-4/#serializing-sRGB-values">serialized sRGB values</a>.</li>
             </ul>
             <p><dfn>codepoint location</dfn> is a struct that captures the location (in [=client coordinate=]s) of codepoints from [=text=].  Each struct represents a contigious run of codepoints starting at an offset within [=text=] indicated by [=start index=].  The struct contains:</p>
             <ul>
@@ -139,7 +152,7 @@
                 [=Editing host=] may not be the best term to use to describe the impact of associating an {{EditContext}} with an {{HTMLElement}}.
                 It has similarities, such as making the {{HTMLElement}} the target for input events, but also differences in that the content of the [=editing host=] is not changed as a result of that input.
             </p>
-            <p>A user agent should have at most one <dfn>active EditContext</dfn>.  An {{EditContext}} is active when its associated element, or a descendant of its associated element is <a href="https://html.spec.whatwg.org/multipage/interaction.html#focused">focused</a>.</p>
+            <p>A user agent should have at most one <dfn>active EditContext</dfn>.  An {{EditContext}} is active when its associated element, or a descendant of its associated element, for which it is an [=editing host=], is <a href="https://html.spec.whatwg.org/multipage/interaction.html#focused">focused</a>.</p>
             <p>When an {{EditContext}} meets the criteria above, it must be made the [=active EditContext=] by running the steps to [=activate an EditContext=].</p>
             <p>If an element associated with an [=active EditContext=] no longer meets the criteria outlined above, run the steps to [=deactivate an EditContext=].</p>
 

--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
                 <li><dfn>selection bounds</dfn> is the rectangle describing the position of selection. It is in the [=client coordinate=] system and the initial x, y, width, and height are all 0.</li>
                 <li><dfn>codepoint locations</dfn> which is an array of [=codepoint location=]. The array is initially empty.</li>
             </ul>
-            <p><dfn>codepoint location</dfn> is a struct that captures the location (in [=client coordinate=]s) of codepoints from [=text=].  Each struct represents a contigious run of codepoints starting at a specified offset.  The struct contains:</p>
+            <p><dfn>codepoint location</dfn> is a struct that captures the location (in [=client coordinate=]s) of codepoints from [=text=].  Each struct represents a contigious run of codepoints starting at an offset within [=text=] indicated by [=start index=].  The struct contains:</p>
             <ul>
                 <li><dfn>start index</dfn> which is an offset into [=text=] that respresents the position before the first codepoint whose location is reported by the first member of [=codepoint rects=] array.</li>
                 <li><dfn>codepoint rects</dfn> is an array of {{DOMRect}} defining the bounding box of each codepoint.</li>
@@ -124,7 +124,11 @@
             <ul>
                 <li><dfn>dirty flag</dfn> which is initially false, but set true by any steps which allow the author to update the state of the {{EditContext}}.</li>
             </ul>
-            <p>Associating an {{EditContext}} to an element makes that element eligible to become an [=editing host=].  An <dfn>editing host</dfn> is as an [=editable element=], but whose parent is not an [=editable element=].</p>
+            <p>
+                Associating an {{EditContext}} to an element makes that element an [=editing host=].  An <dfn>editing host</dfn> is as an [=editable element=] which serves as the target for input events.  
+                Prior to the existence of {{EditContext}}, an [=editing host=] was limited to [=editable element=]s whose parents are not [=editable element=]s.
+                With the introduction of {{EditContext}}, the definition is expanded to include any element associated with an {{EditContext}}.
+            </p>
             <p>A user agent should have at most one <dfn>active EditContext</dfn>.  An {{EditContext}} is active when its associated element, or a descendant of its associated element for which it is the [=editing host=], is the [=active element=] in a [=fully active document=].</p>
             <p>When an {{EditContext}} meets the criteria above, it must be made the [=active EditContext=] by running the steps to [=activate an EditContext=].</p>
             

--- a/index.html
+++ b/index.html
@@ -533,10 +533,18 @@
                         <dd>|textFormats|, a structure that has an array of text format info from the [=Text Input Service=]</dd>
                         <dd>|newSelectionStart|, the new position for the start of the selection</dd>
                         <dd>|newSelectionEnd|, the new position for the end of the selection</dd>
+                        <dd>|isComposing|, </dd>
+                        <dd>|replacementRangeStart|, </dd>
+                        <dd>|replacementRangeEnd|, </dd>
                         <dt>Output</dt>
                         <dd>None</dd>
                     </dl>
             <ol>
+                <li>If the [=active EditContext=] != cached active EditContext
+                    <ol>
+                        <li>Return</li>
+                    </ol>
+                </li>
                 <li>
                     If |newText| is not empty and [=is composing=] is false
                     <ol>

--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
             <ol>
               <li>Instead of deriving the contents of the [=Text Edit Context=] from the DOM, it will be taken from the {{EditContext.text}} property.</li>
               <li>Instead of deriving the location of selection within that text from the document’s selection, the user agent will use the offsets from the {{EditContext.selectionStart}} and {{EditContext.selectionEnd}} properties.</li>
-              <li>Instead of querying the DOM’s associated CSS boxes for the size and position of selection, character bounds, and the editable region of the document, the {{EditContext.selectionBound}}, {{EditContext.characterBounds}} and {{EditContext.controlBound}} will be used.</li>
+              <li>Instead of querying the DOM’s associated CSS boxes for the size and position of selection, character bounds, and the editable region of the document, the {{EditContext.selectionBounds}}, {{EditContext.characterBounds}} and {{EditContext.controlBounds}} will be used.</li>
             </ol>
 
             <p>Using an EditContext, an author can mark a region of the document editable by associating an EditContext object with an element as shown in the example below: </p>
@@ -159,13 +159,13 @@
             this.editContext.updateText(0, this.model.text.length, this.model.text)
             this.editContext.updateSelection(this.model.selectionStart, this.model.selectionEnd)
 
-            let selectionBound = view.computeSelectionBound()  
-            let controlBound = view.computeControlBound()  
+            let selectionBounds = view.computeSelectionBound()  
+            let controlBounds = view.computeControlBound()  
 
             // These bounds have x, y, width and height members  
             // so they can be assigned directly to EditContext.
-            editContext.updateSelectionBound(selectionBound)
-            editContext.updateControlBound(controlBound)
+            editContext.updateSelectionBounds(selectionBounds)
+            editContext.updateControlBoundss(controlBounds)
         }
     }
 
@@ -564,8 +564,8 @@ interface EditContext : EventTarget {
     undefined updateText(unsigned long rangeStart, unsigned long rangeEnd,
         DOMString text);
     undefined updateSelection(unsigned long start, unsigned long end);
-    undefined updateControlBound(DOMRect controlBound);
-    undefined updateSelectionBound(DOMRect selectionBound);
+    undefined updateControlBounds(DOMRect controlBounds);
+    undefined updateSelectionBounds(DOMRect selectionBounds);
     undefined updateCharacterBounds(unsigned long rangeStart, sequence<DOMRect> characterBounds);
 
     sequence<Element> attachedElements();
@@ -576,8 +576,8 @@ interface EditContext : EventTarget {
     readonly attribute unsigned long compositionRangeStart;
     readonly attribute unsigned long compositionRangeEnd;
     readonly attribute boolean isInComposition;
-    readonly attribute DOMRect controlBound;
-    readonly attribute DOMRect selectionBound;
+    readonly attribute DOMRect controlBounds;
+    readonly attribute DOMRect selectionBounds;
     readonly attribute unsigned long characterBoundsRangeStart;
     sequence<DOMRect> characterBounds();
 
@@ -606,14 +606,14 @@ interface EditContext : EventTarget {
             <dt><dfn>isInComposition</dfn>, of type {{boolean}}</dt>
             <dd>Initially false. Whether there is an active composition.</dd>
 
-            <dt><dfn>controlBound</dfn>, of type {{DOMRect}}</dt>
+            <dt><dfn>controlBounds</dfn>, of type {{DOMRect}}</dt>
             <dd>Initially 0s. The bounding box of the display surface where the text is rendered. The offset of the rectangle is expressed relative to the origin of the associated element.</dd>
 
 <p class="note">
     The control bound may be used by the OS for hittesting to trigger the virtual keyboard.
 </p>
 
-            <dt><dfn>selectionBound</dfn>, of type {{DOMRect}}</dt>
+            <dt><dfn>selectionBounds</dfn>, of type {{DOMRect}}</dt>
             <dd>Initially 0s. The bounding box of the selection. The offset of the rectangle is expressed relative to the origin of the associated element. If the selection is collapsed, this is the bounding box of the caret.</dd>
 
             <dt><dfn>characterBoundsRangeStart</dfn>, of type {{unsigned long}}</dt>
@@ -658,7 +658,7 @@ interface EditContext : EventTarget {
                 </ol>
             </dd>
             <dt>
-                <dfn>updateSelectionBound()</dfn> method
+                <dfn>updateSelectionBounds()</dfn> method
             </dt>
               <dd>
                 <p>
@@ -669,12 +669,12 @@ interface EditContext : EventTarget {
                     If the EditContext is not activated, abort these steps.
                   </li>
                   <li>
-                    set {{EditContext/selectionBound}} to <i>selectoinBound</i>.
+                    set {{EditContext/selectionBounds}} to <i>selectoinBound</i>.
                   </li>
                 </ol>
               </dd>
               <dt>
-                <dfn>updateControlBound()</dfn> method
+                <dfn>updateControlBounds()</dfn> method
             </dt>
               <dd>
                 <p>
@@ -685,7 +685,7 @@ interface EditContext : EventTarget {
                     If the EditContext is not activated, abort these steps.
                   </li>
                   <li>
-                    set {{EditContext/controlBound}} to <i>controlBound</i>.
+                    set {{EditContext/controlBounds}} to <i>controlBounds</i>.
                   </li>
                 </ol>
               </dd>
@@ -899,7 +899,7 @@ interface CharacterBoundsUpdateEvent : Event {
             <p>
                 <ul>
                     <li>
-                        User Agent MUST only allow {{EditContext/updateSelection()}}, {{EditContext/updateText()}}, {{EditContext/updateSelectionBound()}}, {{EditContext/updateControlBound()}}, and {{EditContext/updateCharacterBounds()}} methods to be called in a <a href="https://w3c.github.io/webappsec-secure-contexts/">Secure Context</a>.
+                        User Agent MUST only allow {{EditContext/updateSelection()}}, {{EditContext/updateText()}}, {{EditContext/updateSelectionBounds()}}, {{EditContext/updateControlBounds()}}, and {{EditContext/updateCharacterBounds()}} methods to be called in a <a href="https://w3c.github.io/webappsec-secure-contexts/">Secure Context</a>.
                     </li>
                 </ul>
             </p>

--- a/index.html
+++ b/index.html
@@ -104,9 +104,9 @@
 
             <p>Associating an {{EditContext}} to an element makes that element intrinsically [=focusable=].  When the element is focused, the user agent will use the state of the {{EditContext}} to construct a [=Text Edit Context=] that is provided to the [=Text Input Service=] of the OS:</p>
             <ol>
-              <li>Instead of deriving the text content of the [=Text Edit Context=] from the DOM, it will be taken from [=edit context=]'s [=text=].</li>
-              <li>Instead of deriving the location of selection within that text from the document’s selection, the user agent will use [=edit context=]'s [=selection range=].</li>
-              <li>Instead of querying the DOM’s associated CSS boxes for the size and position of selection, character bounds, and the editable region of the document, the user agent will use [=edit context=]'s [=selection bounds=], [=character bounds=], and [=control bounds=] respectively.</li>
+              <li>Instead of deriving the text content of the [=Text Edit Context=] from the DOM, it will be taken from the {{EditContext}}'s [=text=].</li>
+              <li>Instead of deriving the location of selection within that text from the document’s selection, the user agent will use the {{EditContext}}'s [=selection start=] and [=selection end=].</li>
+              <li>Instead of querying the DOM’s associated CSS boxes for the size and position of selection, character bounds, and the editable region of the document, the user agent will use the {{EditContext}}'s [=selection bounds=], [=array of character bounds=], and [=control bounds=] respectively.</li>
             </ol>
 
             <p>Using an {{EditContext}}, an author can mark a region of the document [=editable=] by associating an {{EditContext}} object with an element as shown in the example below: </p>

--- a/index.html
+++ b/index.html
@@ -89,16 +89,21 @@
         </section>
         <section id="editcontext-model">
             <h3>The EditContext Model</h3>
-            <p>An {{EditContext}} is a JavaScript projection of the [=Text Edit Context=] concept discussed in the previous section. Using an {{EditContext}}, an author can mark a region of the document editable by associating an instance of an {{EditContext}} with an element.</p>
             
-            <p>Associating an {{EditContext}} to an element makes that element intrinsically focusable.  When the element is focused, the user agent will use the state of the {{EditContext}} to construct a [=Text Edit Context=] that is provided to the [=Text Input Service=] of the OS:</p>
+            <p>An <dfn>edit context</dfn> is a conceptual object that can be used by the user agent to contruct a [=Text Edit Context=] for the [=Text Input Service=] of the OS.</p>
+            
+            <p>An [=edit context=] has a <dfn>text</dfn> that consists of the plain text of the editable content, a <dfn>selection range</dfn> that marks the start and the end of the current selection, a <dfn>composition range</dfn> that marks the start and the end of the current composition, <dfn>control bounds</dfn> that indicates the bounding box of the display surface, <dfn>selection bounds</dfn> that indicates the bounding box of the selection, <dfn>character bounds</dfn> that indicates the bounding boxes of an array of characters of which the bounding boxes are needed for the [=Text Input Service=] of the OS, and a <dfn>character bounds range start index</dfn> that indicates the index of the first character that is used for the [=character bounds=].
+            
+            <p>An {{EditContext}} is a JavaScript projection of [=edit context=]. Using an {{EditContext}}, an author can mark a region of the document editable by associating an instance of an {{EditContext}} with an element.</p>
+            
+            <p>Associating an {{EditContext}} to an element makes that element intrinsically [=focusable=].  When the element is focused, the user agent will use the state of the [=edit context=] to construct a [=Text Edit Context=] that is provided to the [=Text Input Service=] of the OS:</p>
             <ol>
-              <li>Instead of deriving the contents of the [=Text Edit Context=] from the DOM, it will be taken from the {{EditContext.text}} property.</li>
-              <li>Instead of deriving the location of selection within that text from the document’s selection, the user agent will use the offsets from the {{EditContext.selectionStart}} and {{EditContext.selectionEnd}} properties.</li>
-              <li>Instead of querying the DOM’s associated CSS boxes for the size and position of selection, character bounds, and the editable region of the document, the {{EditContext.selectionBounds}}, {{EditContext.characterBounds}} and {{EditContext.controlBounds}} will be used.</li>
+              <li>Instead of deriving the text content of the [=Text Edit Context=] from the DOM, it will be taken from [=edit context=]'s [=text=].</li>
+              <li>Instead of deriving the location of selection within that text from the document’s selection, the user agent will use [=edit context=]'s [=selection range=].</li>
+              <li>Instead of querying the DOM’s associated CSS boxes for the size and position of selection, character bounds, and the editable region of the document, the user agent will use [=edit context=]'s [=selection bounds=], [=character bounds=], and [=control bounds=] respectively.</li>
             </ol>
 
-            <p>Using an EditContext, an author can mark a region of the document editable by associating an EditContext object with an element as shown in the example below: </p>
+            <p>Using an {{EditContext}}, an author can mark a region of the document [=editable=] by associating an {{EditContext}} object with an element as shown in the example below: </p>
             <aside class="example" title="Associate an EditContext with an Element">
                 <pre><xmp><script type="module"> 
     let canvas = document.querySelector("canvas") 
@@ -447,7 +452,7 @@
         </pre>
         <dfn>editContext</dfn>
         <p>
-            An {{EditContext}}, initially null.
+            An {{EditContext}}, initially null. The {{EditContext}} getter steps are to return [=this=]'s [=editcontext=] object.
         </p>
 
         <p>When an element is associated with an {{EditContext}}, it is focusable regardless of whether its contentediable attribute is true or not.</p>
@@ -554,7 +559,8 @@
     </section>
 
     <section data-dfn-for="EditContext">
-        <h2>The <dfn>EditContext</dfn> Interface</h2>
+        <h2>EditContext API</h2>
+        <h3 id="editcontext-interface">EditContext Interface</h3>
     <pre class="idl"><xmp>dictionary EditContextInit {
     DOMString text;
     unsigned long selectionStart;

--- a/index.html
+++ b/index.html
@@ -654,19 +654,13 @@
 <li> [=Fire an event=] named "characterboundsupdate" with |event|</li>
 </ol>
 </div><!-- algorithm -->
-<h4><dfn>Update Text Input Service</dfn></h4>
+<h4><dfn>Update the Text Edit Context</dfn></h4>
 <div class="algorithm">
-    <div class="note">
-        <p>Some platform implementations require that the [=Text Edit Context=] be able to supply
-        data about its content synchronously.  This is challenging since the most up-to-date data
-        is typically held in JavaScript data structures maintained by the author, and input threads
-        used for text input should generally not be blocked on JavaScript processing.</p>
-        <p>To avoid a blocking implementation, the data required by the [=Text Edit Context=] is stored
-        in the {{EditContext}} by the author.  With each frame, the web platform must copy the
-        contents of the {{EditContext}} to the [=Text Edit Context=].  When the platform's [=Text Input Service=]
-        queries the [=Text Edit Context=], the data used to answer the query will be only a frame behind.</p>
-        <p>The algorithm below captures the steps to copy that data.</p>
-    </div>
+    <p>
+        This processing step must occur as a substep within the [=Update the rendering=] step in the HTML Event Loops Processing Model.
+        The step is: Run the [=Update the Text Edit Context=] steps.
+        It must occur just after substep 13: run the animation frame callbacks steps.
+    </p>
     <dl>
         <dt>Input</dt>
         <dd>None</dd>
@@ -674,9 +668,13 @@
         <dd>None</dd>
     </dl>
     <ol>
-        <li>
-            <div class="note">Add details</div>
-        </li>
+        <li>If the [=active EditContext=] is null, abort these steps.</li>
+        <li>let editContext be the currently [=active EditContext=].</li>
+        <li>If editContext's [=dirty=] flag is false, abort these steps.</li>
+        <li>If editContext's [=has called updateCharacterBounds=] flag is false, run the steps to [=Dispatch character bound update event=].</li>
+        <li>If the [=active EditContext=] is not editContext, abort these steps.</li>
+        <li>let textState be editContext's [=text state=].</li>
+        <li>In parallel, update the [=Text Edit Context=]'s [=text state=] to match the values in textState.</li>
     </ol>
 </div><!-- algorithm -->
 <h4><dfn>Modify BeforeInput Event</dfn></h4>

--- a/index.html
+++ b/index.html
@@ -661,7 +661,7 @@
             <li>Add |textFormat| to |formats|</li>
         </ol>
     </li>
-    <li> [=Fire an event=] named "textformateupdate" at the activated EditContext using {{TextFormatUpdateEvent}} with |formats|</li>
+    <li> [=Fire an event=] named "textformatupdate" at the activated EditContext using {{TextFormatUpdateEvent}} with |formats|</li>
 </ol>
 </div><!-- algorithm -->
 

--- a/index.html
+++ b/index.html
@@ -50,8 +50,7 @@
 
 <body>
     <section id='abstract'>
-        <p>The {{EditContext}} is a new API that allows authors to more directly participate in the text input process.
-        </p>
+        <p>The {{EditContext}} is a new API that allows authors to more directly participate in the text input process.</p>
     </section>
     <section id='sotd'>
       <p>
@@ -120,16 +119,27 @@
                 <li><dfn>start index</dfn> which is an offset into [=text=] that respresents the position before the first codepoint whose location is reported by the first member of [=codepoint rects=] array.</li>
                 <li><dfn>codepoint rects</dfn> is an array of {{DOMRect}} defining the bounding box of each codepoint.</li>
             </ul>
+            <p class="note">
+                [=Codepoint locations=] provides the means for the user agent to query multiple ranges of [=text=] for positioning information.
+                Different platforms may require different positions to be cached to fulfill queries from the [=Text Input Service=] and this API shape allows for that flexibility.
+                It would be good if the API could be simplified to require just the positions of the actively composed text along with the [=selection bounds=] and [=control bounds=].
+                Exploration is needed to see if that is possible.
+            </p>
             <p>In addition to [=text state=], an {{EditContext}} also has:
             <ul>
                 <li><dfn>dirty flag</dfn> which is initially false, but set true by any steps which allow the author to update the state of the {{EditContext}}.</li>
+                <li><dfn>character bounds updated flag</dfn> which is initially false.</li>
             </ul>
             <p>
-                Associating an {{EditContext}} to an element makes that element an [=editing host=].  An <dfn>editing host</dfn> is an [=editable element=] which serves as the target for input events.  
+                Associating an {{EditContext}} to an element makes that element an [=editing host=].  An [=editing host=] is an [=editable element=] which serves as the target for input events.  
                 Prior to the existence of {{EditContext}}, an [=editing host=] was limited to [=editable element=]s whose parents are not [=editable element=]s.
                 With the introduction of {{EditContext}}, the definition is expanded to include any element associated with an {{EditContext}}.
             </p>
-            <p>A user agent should have at most one <dfn>active EditContext</dfn>.  An {{EditContext}} is active when its associated element, or a descendant of its associated element for which it is the [=editing host=], is the [=active element=] in a [=fully active document=].</p>
+            <p class="note">
+                [=Editing host=] may not be the best term to use to describe the impact of associating an {{EditContext}} with an {{HTMLElement}}.
+                It has similarities, such as making the {{HTMLElement}} the target for input events, but also differences in that the content of the [=editing host=] is not changed as a result of that input.
+            </p>
+            <p>A user agent should have at most one <dfn>active EditContext</dfn>.  An {{EditContext}} is active when its associated element, or a descendant of its associated element is [=focused=].</p>
             <p>When an {{EditContext}} meets the criteria above, it must be made the [=active EditContext=] by running the steps to [=activate an EditContext=].</p>
             <p>If an element associated with an [=active EditContext=] no longer meets the criteria outlined above, run the steps to [=deactivate an EditContext=].</p>
             
@@ -486,9 +496,10 @@
                     attribute EditContext? editContext;
                };
             </pre>
+            <p>An {{HTMLElement}} has an internal slot [[\EditContext]], which is a reference to an {{EditContext}} and is intially null.</p>
             <dl>
                 <dt>editContext</dt>
-                <dd>Initially null. The {{HTMLElement/editContext}} getter steps are to return [=this=]'s {{EditContext}} if there is an {{EditContext}} associated.</dd>
+                <dd>The {{HTMLElement/editContext}} getter steps are to return the value of [=this=]'s internal [[\EditContext]] slot.</dd>
                 <dd>The {{HTMLElement/editContext}} setter must follow these steps:
                     <div class="algorithm">
                         <dl>
@@ -497,19 +508,18 @@
                             <dt>Output</dt>
                             <dd>None</dd>
                         </dl>
-                    <ol>
-                    <li>If |editContext| is null
                         <ol>
-                            <li>run [=Detach EditContext=]</li>
+                            <li>Let |oldEditContext| be the value of [=this=]'s internal [[\EditContext]] slot.</li>
+                            <li>Set [=this=]'s internal [[\EditContext]] slot to be |editContext|</li>
+                            <li>If |oldEditContext| is the [=active EditContext=]
+                                <ol>
+                                    <li>Run the steps [=Deactivate an EditContext=] with |oldEditContext|</li>
+                                    <li>Run the steps to [=Activate an EditContext=] with |editContext|</li>
+                                </ol>
+                            </li>
                         </ol>
-                    </li>
-                    <li>Else
-                        <ol>
-                            <li>run [=Attach EditContext=]</li>
-                        </ol>
-                    </li>                    
-                    </ol>
-                    </div><!-- algorithm -->                    
+                    </div><!-- algorithm -->
+                </dd>
             </dl>
    
             <p>When an element is associated with an {{EditContext}}, it is [=editable=] regardless of whether its [=contentediable=] attribute is true or not.</p>
@@ -668,14 +678,18 @@
         <dd>None</dd>
     </dl>
     <ol>
-        <li>If the [=active EditContext=] is null, abort these steps.</li>
         <li>let editContext be the currently [=active EditContext=].</li>
-        <li>If editContext's [=dirty=] flag is false, abort these steps.</li>
-        <li>If editContext's [=has called updateCharacterBounds=] flag is false, run the steps to [=Dispatch character bound update event=].</li>
-        <li>If the [=active EditContext=] is not editContext, abort these steps.</li>
+        <li>If editContext is null, abort these steps.</li>
+        <li>If editContext's [=dirty flag=] is false, abort these steps.</li>
+        <li>If editContext's [=character bounds updated flag=] is false, run the steps to [=Dispatch character bound update event=].</li>
+        <li>If the [=active EditContext=] is no longer editContext, abort these steps.</li>
         <li>let textState be editContext's [=text state=].</li>
         <li>In parallel, update the [=Text Edit Context=]'s [=text state=] to match the values in textState.</li>
     </ol>
+    <p class="note">
+        Note the steps to update the [=Text Edit Context=]'s [=text state=] to match the values in textState is dependent on the nature of the abstraction created over a platform-specific [=Text Input Service=].
+        Those details are not part of this specification.
+    </p>
 </div><!-- algorithm -->
 <h4><dfn>Modify BeforeInput Event</dfn></h4>
 <div class="algorithm">
@@ -692,40 +706,34 @@
 </ol>
 </div><!-- algorithm -->
 
-<h4><dfn>focused</dfn></h4>
+<h4><dfn>Activate an EditContext</dfn></h4>
 <div class="algorithm">
-<ol>
-<li>
-    <div class="note">Add details</div>
-</li>
-</ol>
+    <dl>
+        <dt>Input</dt>
+        <dd>|this| an {{EditContext}}</dd>
+        <dt>Output</dt>
+        <dd>None</dd>
+    </dl>
+    <ol>
+        <li>
+            <div class="note">Add details</div>
+        </li>
+    </ol>
 </div><!-- algorithm -->
 
-<h4><dfn>blurred</dfn></h4>
+<h4><dfn>Deactivate an EditContext</dfn></h4>
 <div class="algorithm">
-<ol>
-<li>
-    <div class="note">Add details</div>
-</li>
-</ol>
-</div><!-- algorithm -->
-
-<h4><dfn>Connect Element</dfn></h4>
-<div class="algorithm">
-<ol>
-<li>
-    <div class="note">Add details</div>
-</li>
-</ol>
-</div><!-- algorithm -->
-
-<h4><dfn>Disconnect Element</dfn></h4>
-<div class="algorithm">
-<ol>
-<li>
-    <div class="note">Add details</div>
-</li>
-</ol>
+    <dl>
+        <dt>Input</dt>
+        <dd>|this| an {{EditContext}}</dd>
+        <dt>Output</dt>
+        <dd>None</dd>
+    </dl>
+    <ol>
+        <li>
+            <div class="note">Add details</div>
+        </li>
+    </ol>
 </div><!-- algorithm -->
 
 <h4><dfn>Attach EditContext</dfn></h4>

--- a/index.html
+++ b/index.html
@@ -11,11 +11,15 @@
             ,shortName:    "edit-context"
             ,editors:      [{ name: "Shih-ling Keng",
                                mailto: "shihken@microsoft.com",
-                               company: "Microsoft Corporation",
+                               company: "Microsoft",
                                w3cid: 126951},
+                               { name: "Anupam Snigdha",
+                               mailto: "snianu@microsoft.com",
+                               company: "Microsoft",
+                               w3cid: 126950},
                                { name: "Bo Cupp",
                                mailto: "pcupp@microsoft.com",
-                               company: "Microsoft Corporation",
+                               company: "Microsoft",
                                w3cid: 126951},]
           ,   wgPublicList: "public-editing-tf"
 	  ,   otherLinks: [{

--- a/index.html
+++ b/index.html
@@ -757,7 +757,7 @@ interface EditContext : EventTarget {
         <h2>EditContext events</h2>
         <section>
             <h3><dfn>TextUpdateEvent</dfn></h3>
-            <pre class="idl"><xmp>dictionary TextUpdateEventInit {
+            <pre class="idl"><xmp>dictionary TextUpdateEventInit : EventInit {
     unsigned long updateRangeStart;
     unsigned long updateRangeEnd;
     DOMString text;
@@ -769,7 +769,7 @@ interface EditContext : EventTarget {
 
 [Exposed=Window]
 interface TextUpdateEvent : Event {
-    constructor(optional TextUpdateEventInit options = {});
+    constructor(DOMString type, optional TextUpdateEventInit options = {});
     readonly attribute unsigned long updateRangeStart;
     readonly attribute unsigned long updateRangeEnd;
     readonly attribute DOMString text;
@@ -825,14 +825,13 @@ interface TextFormat {
     attribute DOMString underlineColor;
 };
 
-dictionary TextFormatUpdateEventInit {
+dictionary TextFormatUpdateEventInit : EventInit {
     sequence<TextFormat> textFormats;
 };
 
 [Exposed=Window]
 interface TextFormatUpdateEvent : Event {
-    constructor(optional TextFormatUpdateEventInit options = {});
-
+    constructor(DOMString type, optional TextFormatUpdateEventInit options = {});
     sequence<TextFormat> getTextFormats();
 };</xmp></pre>
             <dl>
@@ -873,15 +872,14 @@ interface TextFormatUpdateEvent : Event {
         </section>
         <section>
             <h3><dfn>CharacterBoundsUpdateEvent</dfn></h3>
-            <pre class="idl"><xmp>dictionary CharacterBoundsUpdateEventInit {
+            <pre class="idl"><xmp>dictionary CharacterBoundsUpdateEventInit : EventInit {
     unsigned long rangeStart;
     unsigned long rangeEnd;
 };
 
 [Exposed=Window]
 interface CharacterBoundsUpdateEvent : Event {
-    constructor(optional CharacterBoundsUpdateEventInit options = {});
-
+    constructor(DOMString type, optional CharacterBoundsUpdateEventInit options = {});
     readonly attribute unsigned long rangeStart;
     readonly attribute unsigned long rangeEnd;
 };</xmp></pre>

--- a/index.html
+++ b/index.html
@@ -753,7 +753,7 @@ interface EditContext : EventTarget {
         <h2>EditContext events</h2>
         <section>
             <h3><dfn>TextUpdateEvent</dfn></h3>
-            <pre class="idl"><xmp>dictionary TextUpdateEventInit {
+            <pre class="idl"><xmp>dictionary TextUpdateEventInit : EventInit {
     unsigned long updateRangeStart;
     unsigned long updateRangeEnd;
     DOMString text;
@@ -765,7 +765,7 @@ interface EditContext : EventTarget {
 
 [Exposed=Window]
 interface TextUpdateEvent : Event {
-    constructor(optional TextUpdateEventInit options = {});
+    constructor(DOMString type, optional TextUpdateEventInit options = {});
     readonly attribute unsigned long updateRangeStart;
     readonly attribute unsigned long updateRangeEnd;
     readonly attribute DOMString text;
@@ -799,7 +799,7 @@ interface TextUpdateEvent : Event {
         </section>
         <section>
             <h3><dfn>TextFormatUpdateEvent</dfn></h3>
-            <pre class="idl"><xmp>dictionary TextFormatInit {
+            <pre class="idl"><xmp>dictionary TextFormatInit : EventInit {
     unsigned long rangeStart;
     unsigned long rangeEnd;
     DOMString textColor;
@@ -811,7 +811,7 @@ interface TextUpdateEvent : Event {
 
 [Exposed=Window]
 interface TextFormat {
-    constructor(optional TextFormatInit options = {});
+    constructor(DOMString type, optional TextFormatInit options = {});
     attribute unsigned long rangeStart;
     attribute unsigned long rangeEnd;
     attribute DOMString textColor;
@@ -821,14 +821,13 @@ interface TextFormat {
     attribute DOMString underlineColor;
 };
 
-dictionary TextFormatUpdateEventInit {
+dictionary TextFormatUpdateEventInit : EventInit {
     sequence<TextFormat> textFormats;
 };
 
 [Exposed=Window]
 interface TextFormatUpdateEvent : Event {
-    constructor(optional TextFormatUpdateEventInit options = {});
-
+    constructor(DOMString type, optional TextFormatUpdateEventInit options = {});
     sequence<TextFormat> getTextFormats();
 };</xmp></pre>
             <dl>
@@ -869,15 +868,14 @@ interface TextFormatUpdateEvent : Event {
         </section>
         <section>
             <h3><dfn>CharacterBoundsUpdateEvent</dfn></h3>
-            <pre class="idl"><xmp>dictionary CharacterBoundsUpdateEventInit {
+            <pre class="idl"><xmp>dictionary CharacterBoundsUpdateEventInit : EventInit {
     unsigned long rangeStart;
     unsigned long rangeEnd;
 };
 
 [Exposed=Window]
 interface CharacterBoundsUpdateEvent : Event {
-    constructor(optional CharacterBoundsUpdateEventInit options = {});
-
+    constructor(DOMString type, optional CharacterBoundsUpdateEventInit options = {});
     readonly attribute unsigned long rangeStart;
     readonly attribute unsigned long rangeEnd;
 };</xmp></pre>

--- a/index.html
+++ b/index.html
@@ -89,7 +89,34 @@
         </section>
         <section id="editcontext-model">
             <h3>The EditContext Model</h3>
+            <section id="text-input-abstractions">
+                <h3>Text Input Abstractions</h3>
+                <div class="note">
+                    <p>
+                        The [=Text Input Service=] and [=Text Edit Context=] are abstractions representing the common aspects of text input across many operating systems. 
+                        Because {{EditContext}} is a primitive API designed to integrate with these various text input implementations, this spec will first define the [=Text Input Service=] and [=Text Edit Context=] abstractions, and then define how the {{EditContext}} is used by authors to interact with those abstractions.
+                        This specification does not define how a user agent should construct such abstractions.
+                    </p>
+                </div>
+                <p>The [=Text Edit Context=] has a [=TEC text=] array, a [=TEC selection start=] index, a [=TEC selection end=] index, a [=TEC composition start=] index, a [=TEC composition end=] index, a [=TEC is composing=] flag, a [=TEC control bounds=], a [=TEC selection bounds=], and a [=TEC array of character location data=].</p>
+                <p>The <dfn>TEC text</dfn> is a UTF-16 encoded string of code points representing editable content. The initial value is the empty string.</p>
+                <p>The <dfn>TEC selection start</dfn> index identifies the offset of the selection's starting position within [=TEC text=]. The value must be between 0 and the length of [=TEC text=] (inclusive). The initial value is 0.</p>
+                <p>The <dfn>selection end</dfn> position is the end position of the current selection. The initial value is 0.</p>
+                <p>The <dfn>composition start</dfn> position is the start of the current composition. The initial value is 0</p>
+                <p>The <dfn>composition end</dfn> position is the end of the current composition. The initial value is 0</p>
+                <p>The <dfn>is composing</dfn> flag indicates if there is an active composition. The initial value is false</p>
+                <p>The <dfn>control bounds</dfn> is the bounding box of the display surface. It is in the [=client coordinate=] and the initial x, y, width, and height are 0, 0, 0, and 0, respectively.</p>
+                <p>The <dfn>selection bounds</dfn> is the bounding box of the selection. It is in the [=client coordinate=] and the initial x, y, width, and height are 0, 0, 0, 0, respectively.</p>
+                <p>The <dfn>array of character bounds</dfn> consists of the bounding boxes of the rendering result of the characters in a substring of [=text=]. These bounding boxes are used by the [=Text Input Method=] to properly position its user interface. The bounding boxes are in [=client coordinate=] and the array is initially empty.</p>    
+            </section>
             
+            
+            
+            <p>An {{EditContext}} is a JavaScript projection of the [=Text Edit Context=]. Changes made to the [=Text Edit Context=] by the [=Text Input Service=] are communicated to the author in the form of events dispatched against it's associated {{EditContext}}.</p>
+            
+            
+
+            <p></p>
             <p>An {{EditContext}} has a [=text=], a [=selection start=] position, a [=selection end=] position, a [=composition start=] position,  a [=composition end=] position, a [=is composing=] flag, a [=control bounds=], a [=selection bounds=], an [=array of character bounds=] and a [=character bounds range start=] index.
             <p>The <dfn>text</dfn> consists of the plain text of the editable content. The initial value is the empty string.</p>
             <p>The <dfn>selection start</dfn> position is the start position of the current selection. The initial value is 0.</p>

--- a/index.html
+++ b/index.html
@@ -591,7 +591,35 @@
             </ol>
             </div><!-- algorithm -->
 
-            <h4><dfn>Dispatch text update event</dfn></h4>
+<h4><dfn>Update the Text Edit Context</dfn></h4>
+<div class="algorithm">
+    <p>
+        This processing step must occur as a substep within the [=Update the rendering=] step in the HTML Event Loops Processing Model.
+        The step is: Run the [=Update the Text Edit Context=] steps.
+        It must occur just after substep 13: run the animation frame callbacks steps.
+    </p>
+    <dl>
+        <dt>Input</dt>
+        <dd>None</dd>
+        <dt>Output</dt>
+        <dd>None</dd>
+    </dl>
+    <ol>
+        <li>let editContext be the currently [=active EditContext=].</li>
+        <li>If editContext is null, abort these steps.</li>
+        <li>If editContext's [=dirty flag=] is false, abort these steps.</li>
+        <li>If editContext's [=character bounds updated flag=] is false, run the steps to [=Dispatch character bounds update event=].</li>
+        <li>If the [=active EditContext=] is no longer editContext, abort these steps.</li>
+        <li>let textState be editContext's [=text state=].</li>
+        <li>In parallel, update the [=Text Edit Context=]'s [=text state=] to match the values in textState.</li>
+    </ol>
+    <p class="note">
+        Note the steps to update the [=Text Edit Context=]'s [=text state=] to match the values in textState is dependent on the nature of the abstraction created over a platform-specific [=Text Input Service=].
+        Those details are not part of this specification.
+    </p>
+</div><!-- algorithm -->
+
+<h4><dfn>Dispatch text update event</dfn></h4>
         <div class="algorithm">
             <dl>
                 <dt>Input</dt>
@@ -651,33 +679,6 @@
 </li>
 <li> [=Fire an event=] named "characterboundsupdate" with |event|</li>
 </ol>
-</div><!-- algorithm -->
-<h4><dfn>Update the Text Edit Context</dfn></h4>
-<div class="algorithm">
-    <p>
-        This processing step must occur as a substep within the [=Update the rendering=] step in the HTML Event Loops Processing Model.
-        The step is: Run the [=Update the Text Edit Context=] steps.
-        It must occur just after substep 13: run the animation frame callbacks steps.
-    </p>
-    <dl>
-        <dt>Input</dt>
-        <dd>None</dd>
-        <dt>Output</dt>
-        <dd>None</dd>
-    </dl>
-    <ol>
-        <li>let editContext be the currently [=active EditContext=].</li>
-        <li>If editContext is null, abort these steps.</li>
-        <li>If editContext's [=dirty flag=] is false, abort these steps.</li>
-        <li>If editContext's [=character bounds updated flag=] is false, run the steps to [=Dispatch character bounds update event=].</li>
-        <li>If the [=active EditContext=] is no longer editContext, abort these steps.</li>
-        <li>let textState be editContext's [=text state=].</li>
-        <li>In parallel, update the [=Text Edit Context=]'s [=text state=] to match the values in textState.</li>
-    </ol>
-    <p class="note">
-        Note the steps to update the [=Text Edit Context=]'s [=text state=] to match the values in textState is dependent on the nature of the abstraction created over a platform-specific [=Text Input Service=].
-        Those details are not part of this specification.
-    </p>
 </div><!-- algorithm -->
 
 <h4><dfn>Activate an EditContext</dfn></h4>

--- a/index.html
+++ b/index.html
@@ -757,7 +757,7 @@ interface EditContext : EventTarget {
         <h2>EditContext events</h2>
         <section>
             <h3><dfn>TextUpdateEvent</dfn></h3>
-            <pre class="idl"><xmp>dictionary TextUpdateEventInit : EventInit {
+            <pre class="idl"><xmp>dictionary TextUpdateEventInit {
     unsigned long updateRangeStart;
     unsigned long updateRangeEnd;
     DOMString text;
@@ -769,7 +769,7 @@ interface EditContext : EventTarget {
 
 [Exposed=Window]
 interface TextUpdateEvent : Event {
-    constructor(DOMString type, optional TextUpdateEventInit options = {});
+    constructor(optional TextUpdateEventInit options = {});
     readonly attribute unsigned long updateRangeStart;
     readonly attribute unsigned long updateRangeEnd;
     readonly attribute DOMString text;
@@ -803,7 +803,7 @@ interface TextUpdateEvent : Event {
         </section>
         <section>
             <h3><dfn>TextFormatUpdateEvent</dfn></h3>
-            <pre class="idl"><xmp>dictionary TextFormatInit : EventInit {
+            <pre class="idl"><xmp>dictionary TextFormatInit {
     unsigned long rangeStart;
     unsigned long rangeEnd;
     DOMString textColor;
@@ -815,7 +815,7 @@ interface TextUpdateEvent : Event {
 
 [Exposed=Window]
 interface TextFormat {
-    constructor(DOMString type, optional TextFormatInit options = {});
+    constructor(optional TextFormatInit options = {});
     attribute unsigned long rangeStart;
     attribute unsigned long rangeEnd;
     attribute DOMString textColor;
@@ -825,13 +825,14 @@ interface TextFormat {
     attribute DOMString underlineColor;
 };
 
-dictionary TextFormatUpdateEventInit : EventInit {
+dictionary TextFormatUpdateEventInit {
     sequence<TextFormat> textFormats;
 };
 
 [Exposed=Window]
 interface TextFormatUpdateEvent : Event {
-    constructor(DOMString type, optional TextFormatUpdateEventInit options = {});
+    constructor(optional TextFormatUpdateEventInit options = {});
+
     sequence<TextFormat> getTextFormats();
 };</xmp></pre>
             <dl>
@@ -872,14 +873,15 @@ interface TextFormatUpdateEvent : Event {
         </section>
         <section>
             <h3><dfn>CharacterBoundsUpdateEvent</dfn></h3>
-            <pre class="idl"><xmp>dictionary CharacterBoundsUpdateEventInit : EventInit {
+            <pre class="idl"><xmp>dictionary CharacterBoundsUpdateEventInit {
     unsigned long rangeStart;
     unsigned long rangeEnd;
 };
 
 [Exposed=Window]
 interface CharacterBoundsUpdateEvent : Event {
-    constructor(DOMString type, optional CharacterBoundsUpdateEventInit options = {});
+    constructor(optional CharacterBoundsUpdateEventInit options = {});
+
     readonly attribute unsigned long rangeStart;
     readonly attribute unsigned long rangeEnd;
 };</xmp></pre>

--- a/index.html
+++ b/index.html
@@ -658,20 +658,6 @@
         Those details are not part of this specification.
     </p>
 </div><!-- algorithm -->
-<h4><dfn>Modify BeforeInput Event</dfn></h4>
-<div class="algorithm">
-    <dl>
-        <dt>Input</dt>
-        <dd>None</dd>
-        <dt>Output</dt>
-        <dd>None</dd>
-    </dl>
-<ol>
-<li>
-    <div class="note">Add details</div>
-</li>
-</ol>
-</div><!-- algorithm -->
 
 <h4><dfn>Activate an EditContext</dfn></h4>
 <div class="algorithm">
@@ -701,24 +687,6 @@
             <div class="note">Add details</div>
         </li>
     </ol>
-</div><!-- algorithm -->
-
-<h4><dfn>Attach EditContext</dfn></h4>
-<div class="algorithm">
-<ol>
-<li>
-    <div class="note">Add details</div>
-</li>
-</ol>
-</div><!-- algorithm -->
-
-<h4><dfn>Detach EditContext</dfn></h4>
-<div class="algorithm">
-<ol>
-<li>
-    <div class="note">Add details</div>
-</li>
-</ol>
 </div><!-- algorithm -->
 
         </section>

--- a/index.html
+++ b/index.html
@@ -1049,13 +1049,13 @@ interface TextUpdateEvent : Event {
 [Exposed=Window]
 interface TextFormat {
     constructor(optional TextFormatInit options = {});
-    attribute unsigned long rangeStart;
-    attribute unsigned long rangeEnd;
-    attribute DOMString textColor;
-    attribute DOMString backgroundColor;
-    attribute DOMString underlineStyle;
-    attribute DOMString underlineThickness;
-    attribute DOMString underlineColor;
+    readonly attribute unsigned long rangeStart;
+    readonly attribute unsigned long rangeEnd;
+    readonly attribute DOMString textColor;
+    readonly attribute DOMString backgroundColor;
+    readonly attribute DOMString underlineStyle;
+    readonly attribute DOMString underlineThickness;
+    readonly attribute DOMString underlineColor;
 };
 
 dictionary TextFormatUpdateEventInit : EventInit {
@@ -1068,39 +1068,23 @@ interface TextFormatUpdateEvent : Event {
     sequence<TextFormat> getTextFormats();
 };</xmp></pre>
             <dl>
-                <dt>{{TextFormat/rangeStart}}, of type unsigned long, readonly
-                </dt>
-                <dd>The start position of the range where the format is applied.
-                </dd>
-                <dt>{{TextFormat/rangeEnd}}, of type unsigned long, readonly
-                </dt>
-                <dd>The end position of the range where the format is applied.
-                </dd>
-                <dt>{{TextFormat/textColor}}, of type {{DOMString}}, readonly
-                </dt>
-                <dd>The color of the text. The value is a <a href="https://www.w3.org/TR/css-color-4/#serializing-sRGB-values">serialized sRGB values</a>.
-                </dd>
-                <dt>{{TextFormat/backgroundColor}}, of type {{DOMString}}, readonly
-                </dt>
-                <dd>The color of the background. The value is a <a href="https://www.w3.org/TR/css-color-4/#serializing-sRGB-values">serialized sRGB values</a>.
-                </dd>
-                <dt>{{TextFormat/underlineStyle}}, of type {{DOMString}}, readonly
-                </dt>
-                <dd>The style of the underline. The value is one of the following strings: "None", "Solid", "Dotted", "Dashed", and "Wavy".
-                </dd>
-                <dt>{{TextFormat/underlineThickness}}, of type {{DOMString}}, readonly
-                </dt>
-                <dd>The thickness of the underline. The value is one of the following strings: "None", "Thin", and "Thick".
-                </dd>
-                <dt>{{TextFormat/underlineColor}}, of type {{DOMString}}, readonly
-                </dt>
-                <dd>The color of the underline. The value is a <a href="https://www.w3.org/TR/css-color-4/#serializing-sRGB-values">serialized sRGB values</a>.
-                </dd>
-
+                <dt>rangeStart</dt>
+                <dd>The {{TextFormat/rangeStart}} getter steps are to return [=this=]'s [=rangeStart=].</dd>
+                <dt>rangeEnd</dt>
+                <dd>The {{TextFormat/rangeEnd}} getter steps are to return [=this=]'s [=rangeEnd=].</dd>
+                <dt>textColor</dt>
+                <dd>The {{TextFormat/textColor}} getter steps are to return [=this=]'s [=textColor=].</dd>
+                <dt>backgroundColor</dt>
+                <dd>The {{TextFormat/backgroundColor}} getter steps are to return [=this=]'s [=backgroundColor=].</dd>
+                <dt>underlineStyle</dt>
+                <dd>The {{TextFormat/underlineStyle}} getter steps are to return [=this=]'s [=underlineStyle=].</dd>
+                <dt>underlineThickness</dt>
+                <dd>The {{TextFormat/underlineThickness}} getter steps are to return [=this=]'s [=underlineThickness=].</dd>
+                <dt>underlineColor</dt>
+                <dd>The {{TextFormat/underlineColor}} getter steps are to return [=this=]'s [=underlineColor=].</dd>
                 <dt>{{TextFormatUpdateEvent/getTextFormats}} method
                 </dt>
-                <dd>Returns an array of {{TextFormat}} that describes how {{EditContext/text}} should be formatted in the DOM.
-                </dd>
+                <dd>Returns [=this=]'s cached [=text formats=].</dd>
             </dl>
         </section>
         <section>

--- a/index.html
+++ b/index.html
@@ -435,9 +435,9 @@
     </section>
 
     <section data-dfn-for="Element">
-        <h2>Extensions to the <dfn>Element</dfn> interface</h2>
+        <h2>Extensions to the <dfn>HTMLElement</dfn> interface</h2>
         <pre class="idl">
-           partial interface Element {
+           partial interface HTMLElement {
                 attribute EditContext? editContext;
            };
         </pre>

--- a/index.html
+++ b/index.html
@@ -142,7 +142,11 @@
             <p>A user agent should have at most one <dfn>active EditContext</dfn>.  An {{EditContext}} is active when its associated element, or a descendant of its associated element is <a href="https://html.spec.whatwg.org/multipage/interaction.html#focused">focused</a>.</p>
             <p>When an {{EditContext}} meets the criteria above, it must be made the [=active EditContext=] by running the steps to [=activate an EditContext=].</p>
             <p>If an element associated with an [=active EditContext=] no longer meets the criteria outlined above, run the steps to [=deactivate an EditContext=].</p>
+
+            <p>When there is an [=active EditContext=] and there is a text input from the [=Text Input Service=], the user agent must not modify the DOM and must not fire any <a href=https://w3c.github.io/input-events>InputEvent</a>.</p>
             
+            <p>When there is an [=active EditContext=] and there is a text input from the [=Text Input Service=], the user agent must run [=Update the EditContext=].</p>
+
 
             <p>Using an {{EditContext}}, an author can mark a region of the document [=editable=] by associating an {{EditContext}} object with an element as shown in the example below: </p>
             <aside class="example" title="Associate an EditContext with an Element">
@@ -521,22 +525,7 @@
                     </div><!-- algorithm -->
                 </dd>
             </dl>
-   
-            <p>When an element is associated with an {{EditContext}}, it is [=editable=] regardless of whether its [=contentediable=] attribute is true or not.</p>
-    
-            <p>An element's {{EditContext}} is [=activated=] when the element is <a href="https://html.spec.whatwg.org/multipage/interaction.html#focused">focused</a>, and deactivated when the associated element is [=blurred=].</p>
-    
-            <p>When an {{EditContext}} is [=activated=], the user agent must not modify the DOM when there is user text input from the [=Text Input Service=], instead, the user agent must run [=Update the composition=] if the text input is a composition, and [=Update the text=] if the text input is not a composition.</p>
-
-            <p>When an {{EditContext}} is [=activated=], the user agent must [=Update Text Input Service=] with the current state of the activated {{EditContext}} at least once every frame.</p>
-
-            <p>When an {{EditContext}} is [=activated=] and there is user text input from the [=Text Input Service=], the user agent must [=Modify BeforeInput Event=]'s behavior and must not fire any [=InputEvent=].</p>
-
-            <p>When an element with an associated {{EditContext}} is connected to the tree, the user agent must run [=Connect Element=].</p>
-
-            <p>When an element with an associated {{EditContext}} is disconnected from the tree, the user agent must run [=Disconnect Element=].</p>
-
-                <h4><dfn>Update the composition</dfn></h4>
+                <h4><dfn>Update the EditContext</dfn></h4>
                 <div class="algorithm">
                     <dl>
                         <dt>Input</dt>
@@ -580,25 +569,6 @@
                 <li>[=Dispatch character bounds update event=]</li>
             </ol>
             </div><!-- algorithm -->
-
-            <h4><dfn>Update the text</dfn></h4>
-            <div class="algorithm">
-                <dl>
-                    <dt>Input</dt>
-                    <dd>|newText|, a string</dd>
-                    <dt>Output</dt>
-                    <dd>None</dd>
-                </dl>
-
-                <ol>
-                    <li>
-                        Replace the substring of [=text=] in the range of [=selection start=] and [=selection end=] with |newText|
-                    </li>
-                    <li>Set [=selection start=] to [=selection start=] plus the length of |newText|</li>
-                    <li>Set [=selection end=] to [=selection start=]</li>
-                    <li>[=Dispatch text update event=] with |newText|</li>
-                </ol>
-            </div>
 
             <h4><dfn>Dispatch text update event</dfn></h4>
         <div class="algorithm">
@@ -678,7 +648,7 @@
         <li>let editContext be the currently [=active EditContext=].</li>
         <li>If editContext is null, abort these steps.</li>
         <li>If editContext's [=dirty flag=] is false, abort these steps.</li>
-        <li>If editContext's [=character bounds updated flag=] is false, run the steps to [=Dispatch character bound update event=].</li>
+        <li>If editContext's [=character bounds updated flag=] is false, run the steps to [=Dispatch character bounds update event=].</li>
         <li>If the [=active EditContext=] is no longer editContext, abort these steps.</li>
         <li>let textState be editContext's [=text state=].</li>
         <li>In parallel, update the [=Text Edit Context=]'s [=text state=] to match the values in textState.</li>

--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
             
             <p>An <dfn>edit context</dfn> is a conceptual object that can be used by the user agent to contruct a [=Text Edit Context=] for the [=Text Input Service=] of the OS.</p>
             
-            <p>An [=edit context=] has a <dfn>text</dfn> that consists of the plain text of the editable content, a <dfn>selection range</dfn> that marks the start and the end of the current selection, a <dfn>composition range</dfn> that marks the start and the end of the current composition, <dfn>control bounds</dfn> that indicates the bounding box of the display surface, <dfn>selection bounds</dfn> that indicates the bounding box of the selection, <dfn>character bounds</dfn> that indicates the bounding boxes of an array of characters of which the bounding boxes are needed for the [=Text Input Service=] of the OS, and a <dfn>character bounds range start index</dfn> that indicates the index of the first character that is used for the [=character bounds=].
+            <p>An [=edit context=] has a <dfn>text</dfn> that consists of the plain text of the editable content, a <dfn>selection range</dfn> that marks the start and the end of the current selection, a <dfn>composition range</dfn> that marks the start and the end of the current composition, <dfn>control bounds</dfn> that indicates the bounding box of the display surface, <dfn>selection bounds</dfn> that indicates the bounding box of the selection, <dfn>character bounds</dfn> that indicates the bounding boxes of an array of characters of which the bounding boxes are needed for the [=Text Input Service=] of the OS, and a <dfn>character bounds range start</dfn> index that indicates the index of the first character that is used for the [=character bounds=].
             
             <p>An {{EditContext}} is a JavaScript projection of [=edit context=]. Using an {{EditContext}}, an author can mark a region of the document editable by associating an instance of an {{EditContext}} with an element.</p>
             
@@ -443,66 +443,246 @@
         </p>
     </section>
 
-    <section data-dfn-for="Element">
-        <h2>Extensions to the <dfn>HTMLElement</dfn> interface</h2>
-        <pre class="idl">
-           partial interface HTMLElement {
-                attribute EditContext? editContext;
-           };
-        </pre>
-        <dfn>editContext</dfn>
-        <p>
-            An {{EditContext}}, initially null. The {{EditContext}} getter steps are to return [=this=]'s [=editcontext=] object.
-        </p>
 
-        <p>When an element is associated with an {{EditContext}}, it is focusable regardless of whether its contentediable attribute is true or not.</p>
 
-        <p>An {{EditContext}} is activated when the associated element is focused and deactivated when the associated element is blurred.</p>
+    <section data-dfn-for="EditContext">
+        <h2>EditContext API</h2>
 
-        <p>When an {{EditContext}} is activated, user text input MUST NOT modify DOM, instead, below steps should be implemented:</p>
+        <section data-dfn-for="Element">
+            <h3>Extensions to the HTMLElement interface</h3>
+            <pre class="idl">
+               partial interface HTMLElement {
+                    attribute EditContext? editContext;
+               };
+            </pre>
+            <dl>
+                <dt>editContext, of type {{EditContext}}</dt>
+                <dd>initially null. The {{HTMLElement/editContext}} getter steps are to return [=this=]'s [=edit context=].</dd>
+            </dl>
+   
+            <p>When an element is associated with an {{EditContext}}, it is focusable regardless of whether its [=contentediable=] attribute is true or not.</p>
+    
+            <p>An element's [=edit context=] is [=activated=] when the element is focused and deactivated when the associated element is blurred.</p>
+    
+            <p>When an [=edit context=] is activated, the user agent MUST NOT modify the DOM when there is [=user text input=], instead, below steps should be implemented:</p>
+    
+            <p>If in a [=composition=]: </p>
+            <ol>
+                <li>
+                    [=Fire an event=] named "beforeinput", if applicable to the user text input, at the focused element. If the beforeinput event is cancelled, abort these steps.
+                </li>
+                <li>
+                    Update [=text=], [=selection range=], [=composition range=] of the activated [=edit context=] according to the [=Text Input Service=] of the OS.
+                </li>
+                <li>
+                    [=Fire an event=] named "compositionstart" at the activated [=edit context=] if it's a [=start of a composition=].
+                </li>
+                <li>
+                    [=Fire an event=] named "textupdate" at the activated [=edit context=].
+                </li>
+                <li>
+                    [=Fire an event=] named "textformateupdate" at the activated [=edit context=].
+                </li>
+                <li>
+                    [=Fire an event=] named "characterboundsupdate" at the activated [=edit context=].
+                </li>
+                <li>
+                    [=Fire an event=] named "compositionend" at the activated [=edit context=] if it's an [=end of a composition=].
+                </li>
+            </ol>
+            <p>If not in a composition: </p>
+            <ol>
+                <li>
+                    [=Fire an event=] named "beforeinput", if applicable to the user text input, at the focused element. If the beforeinput event is cancelled, abort these steps.
+                </li>
+                <li>
+                    Update [=text=], [=selection range=] of the activated [=edit context=] according to the user text input.
+                </li>
+                <li>
+                    [=Fire an event=] named "textupdate" at the activated EditContext.
+                </li>
+                <li>
+                    [=Fire an event=] named "characterboundsupdate" at the activated EditContext.
+                </li>
+            </ol>
+            <p>
+                An [=edit context=] can be associated with multiple elements but only the element that has focus will receive beforeinput events.
+            </p>
+        </section>
+        <h3 id="editcontext-interface">EditContext Interface</h3>
+    <pre class="idl"><xmp>dictionary EditContextInit {
+    DOMString text;
+    unsigned long selectionStart;
+    unsigned long selectionEnd;
+};
 
-        <p>If in a composition: </p>
-        <ol>
-            <li>
-                [=Fire an event=] named "beforeinput", if applicable to the user text input, at the focused element. If the beforeinput event is cancelled, abort these steps.
-            </li>
-            <li>
-                Update the {{EditContext/text}}, {{EditContext/selectionStart}}, {{EditContext/selectionEnd}}, {{EditContext/compositionRangeStart}}, {{EditContext/compositionRangeEnd}}, and {{EditContext/isInComposition}} properties of the activated EditContext.
-            </li>
-            <li>
-                [=Fire an event=] named "compositionstart" at the activated EditContext if it's a start of a composition.
-            </li>
-            <li>
-                [=Fire an event=] named "textupdate" at the activated EditContext.
-            </li>
-            <li>
-                [=Fire an event=] named "textformateupdate" at the activated EditContext.
-            </li>
-            <li>
-                [=Fire an event=] named "characterboundsupdate" at the activated EditContext.
-            </li>
-            <li>
-                [=Fire an event=] named "compositionend" at the activated EditContext if it's an end of a composition.
-            </li>
-        </ol>
-        <p>If not in a composition: </p>
-        <ol>
-            <li>
-                [=Fire an event=] named "beforeinput", if applicable to the user text input, at the focused element. If the beforeinput event is cancelled, abort these steps.
-            </li>
-            <li>
-                Update the {{EditContext/text}}, {{EditContext/selectionStart}}, {{EditContext/selectionEnd}}, {{EditContext/compositionRangeStart}}, {{EditContext/compositionRangeEnd}}, and {{EditContext/isInComposition}} properties of the activated EditContext.
-            </li>
-            <li>
-                [=Fire an event=] named "textupdate" at the activated EditContext.
-            </li>
-            <li>
-                [=Fire an event=] named "characterboundsupdate" at the activated EditContext.
-            </li>
-        </ol>
-        <p>
-            An {{EditContext}} can be associated with multiple elements but only the element that has focus will receive beforeinput events.
-        </p>
+[Exposed=Window]
+interface EditContext : EventTarget {
+    constructor(optional EditContextInit options = {});
+
+    undefined updateText(unsigned long rangeStart, unsigned long rangeEnd,
+        DOMString text);
+    undefined updateSelection(unsigned long start, unsigned long end);
+    undefined updateControlBounds(DOMRect controlBounds);
+    undefined updateSelectionBounds(DOMRect selectionBounds);
+    undefined updateCharacterBounds(unsigned long rangeStart, sequence<DOMRect> characterBounds);
+
+    sequence<Element> attachedElements();
+
+    readonly attribute DOMString text;
+    readonly attribute unsigned long selectionStart;
+    readonly attribute unsigned long selectionEnd;
+    readonly attribute unsigned long compositionRangeStart;
+    readonly attribute unsigned long compositionRangeEnd;
+    readonly attribute boolean isInComposition;
+    readonly attribute DOMRect controlBounds;
+    readonly attribute DOMRect selectionBounds;
+    readonly attribute unsigned long characterBoundsRangeStart;
+    sequence<DOMRect> characterBounds();
+
+    attribute EventHandler ontextupdate;
+    attribute EventHandler ontextformatupdate;
+    attribute EventHandler oncharacterboundsupdate;
+    attribute EventHandler oncompositionstart;
+    attribute EventHandler oncompositionend;
+};</xmp></pre>
+        <dl>
+            <dt>text</dt>
+            <dd>The {{EditContext/text}} getter steps are to return [=this=]'s [=edit context=]'s [=text=].</dd>
+
+            <dt>selectionStart</dt>
+            <dd>The {{EditContext/selectionStart}} getter steps are to return the index of the start of [=this=]'s [=edit context=]'s [=selection range=].</dd>
+
+            <dt>selectionEnd</dt>
+            <dd>The {{EditContext/selectionEnd}} getter steps are to return the index of the end of [=this=]'s [=edit context=]'s [=selection range=].</dd>
+
+            <dt>compositionRangeStart</dt>
+            <dd>The {{EditContext/compositionRangeStart}} getter steps are to return the index of the start of [=this=]'s [=edit context=]'s [=composition range=].</dd>
+
+            <dt>compositionRangeEnd</dt>
+            <dd>The {{EditContext/compositionRangeEnd}} getter steps are to return the index of the end of [=this=]'s [=edit context=]'s [=composition range=].</dd>
+
+            <dt>isInComposition</dt>
+            <dd>The {{EditContext/isInComposition}} getter steps are to return there is an active composition.</dd>
+
+            <dt>controlBounds</dt>
+            <dd>The {{EditContext/compositionRangeEnd}} getter steps are to return [=this=]'s [=edit context=]'s [=control bounds=].</dd>
+
+<p class="note">
+    The control bound may be used by the OS for hittesting to trigger the virtual keyboard.
+</p>
+
+            <dt>selectionBounds</dt>
+            <dd>The {{EditContext/selectionBounds}} getter steps are to return [=this=]'s [=edit context=]'s [=selection bounds=].</dd>
+
+            <dt>characterBounds</dt>
+            <dd>The {{EditContext/characterBounds}} getter steps are to return [=this=]'s [=edit context=]'s [=character bounds=].</dd>
+
+            <dt>characterBoundsRangeStart</dt>
+            <dd>The {{EditContext/characterBoundsRangeStart}} getter steps are to return [=this=]'s [=character bounds range start=]'s [=character bounds=].</dd>
+
+            <dt>updateSelection() method</dt>
+            <dd>
+                <p>
+                  The method must follow these steps:
+                </p>
+                <ol>
+                  <li>
+                    If the EditContext is not activated, abort these steps.
+                  </li>
+                  <li>
+                    If start > end, abort these steps.
+                  </li>
+                  <li>
+                    set the start of the [=selection range=] to <i>start</i>
+                  </li>
+                  <li>
+                    set the end of the [=selection range=] to <i>end</i>
+                  </li>
+                </ol>
+            </dd>
+            <dt>updateSelectionBounds() method</dt>
+              <dd>
+                <p>
+                  The method must follow these steps:
+                </p>
+                <ol>
+                  <li>
+                    If the [=edit context=] is not activated, abort these steps.
+                  </li>
+                  <li>
+                    set [=selection bounds=] to <i>selectoinBound</i>.
+                  </li>
+                </ol>
+              </dd>
+              <dt>updateControlBounds() method</dt>
+              <dd>
+                <p>
+                  The method must follow these steps:
+                </p>
+                <ol>
+                  <li>
+                    If the [=edit context=] is not activated, abort these steps.
+                  </li>
+                  <li>
+                    set [=control bounds=] to <i>controlBounds</i>.
+                  </li>
+                </ol>
+              </dd>
+              <dt>updateCharacterBounds() method</dt>
+              <dd>
+                <p>
+                  The method must follow these steps:
+                </p>
+                <ol>
+                  <li>
+                    If the EditContext is not activated, abort these steps.
+                  </li>
+                  <li>
+                    Set the [=character bounds range start=] index to <i>rangeStart</i>.
+                  </li>
+                  <li>
+                    Set [=character bounds=] to <i>characterBounds</i>.
+                  </li>
+                </ol>
+              </dd>
+
+            <dt>updateText() method</dt>
+              <dd>
+                <p>
+                  The method must follow these steps:
+                </p>
+                <ol>
+                  <li>
+                    If the EditContext is not activated, abort these steps.
+                  </li>
+                  <li>
+                    Replace the string in the range of <i>rangeStart</i> and <i>rangeEnd</i> of {{EditContext/text}} with <i>text</i>.
+                  </li>
+                </ol>
+              </dd>
+
+            <dt>attachedElements() method</dt>
+            <dd><p>The method returns elements that are associated with the EditContext.</p></dd>
+            <p class="issue">
+                should attachedElements() return elements that are removed from the tree? If yes, the EditContext will keep removed elements alive. If not, we probably shouldn't allow a disconnected element to associate with EditContext, otherwise, it would be confusing/unintuitive that we allow it but attachedElements returns empty.
+            </p>
+            
+            <dt>ontextupdate</dt>
+            <dd><p>The event handler for {{TextUpdateEvent}}.</p></dd>
+
+            <dt>oncharacterboundsupdate</dt>
+            <dd><p>The event handler for {{CharacterBoundsUpdateEvent}}.</p></dd>
+
+            <dt>ontextformatupdate</dt>
+            <dd><p>The event handler for {{TextFormatUpdateEvent}}.</p></dd>
+
+            <dt>oncompositionstart</dt>
+            <dd><p>The event handler for the <a href='https://w3c.github.io/uievents/#event-type-compositionstart'>compositionstart</a> event.</p></dd>
+
+            <dt>oncompositionend</dt>
+            <dd><p>The event handler for the <a href='https://w3c.github.io/uievents/#event-type-compositionend'>compositionend</a> event.</p></dd>
+        </dl>
         <section>
             <h3>Supported elements</h3>
             <p>Below is the list of elements that can be associated with {{EditContext}}: abbr, 
@@ -558,211 +738,10 @@
 
     </section>
 
-    <section data-dfn-for="EditContext">
-        <h2>EditContext API</h2>
-        <h3 id="editcontext-interface">EditContext Interface</h3>
-    <pre class="idl"><xmp>dictionary EditContextInit {
-    DOMString text;
-    unsigned long selectionStart;
-    unsigned long selectionEnd;
-};
-
-[Exposed=Window]
-interface EditContext : EventTarget {
-    constructor(optional EditContextInit options = {});
-
-    undefined updateText(unsigned long rangeStart, unsigned long rangeEnd,
-        DOMString text);
-    undefined updateSelection(unsigned long start, unsigned long end);
-    undefined updateControlBounds(DOMRect controlBounds);
-    undefined updateSelectionBounds(DOMRect selectionBounds);
-    undefined updateCharacterBounds(unsigned long rangeStart, sequence<DOMRect> characterBounds);
-
-    sequence<Element> attachedElements();
-
-    readonly attribute DOMString text;
-    readonly attribute unsigned long selectionStart;
-    readonly attribute unsigned long selectionEnd;
-    readonly attribute unsigned long compositionRangeStart;
-    readonly attribute unsigned long compositionRangeEnd;
-    readonly attribute boolean isInComposition;
-    readonly attribute DOMRect controlBounds;
-    readonly attribute DOMRect selectionBounds;
-    readonly attribute unsigned long characterBoundsRangeStart;
-    sequence<DOMRect> characterBounds();
-
-    attribute EventHandler ontextupdate;
-    attribute EventHandler ontextformatupdate;
-    attribute EventHandler oncharacterboundsupdate;
-    attribute EventHandler oncompositionstart;
-    attribute EventHandler oncompositionend;
-};</xmp></pre>
-        <dl>
-            <dt><dfn>text</dfn>, of type {{DOMString}}</dt>
-            <dd>Initially empty string. The plain text view of the editable content.</dd>
-
-            <dt><dfn>selectionStart</dfn>, of type {{unsigned long}}</dt>
-            <dd>Initially 0. The start position of the selection.</dd>
-
-            <dt><dfn>selectionEnd</dfn>, of type {{unsigned long}}</dt>
-            <dd>Initially 0. The end position of the selection.</dd>
-
-            <dt><dfn>compositionRangeStart</dfn>, of type {{unsigned long}}</dt>
-            <dd>Initially 0. The start position of the composition.</dd>
-
-            <dt><dfn>compositionRangeEnd</dfn>, of type {{unsigned long}}</dt>
-            <dd>Initially 0. The end position of the composition.</dd>
-
-            <dt><dfn>isInComposition</dfn>, of type {{boolean}}</dt>
-            <dd>Initially false. Whether there is an active composition.</dd>
-
-            <dt><dfn>controlBounds</dfn>, of type {{DOMRect}}</dt>
-            <dd>Initially 0s. The bounding box of the display surface where the text is rendered. The offset of the rectangle is expressed relative to the origin of the associated element.</dd>
-
-<p class="note">
-    The control bound may be used by the OS for hittesting to trigger the virtual keyboard.
-</p>
-
-            <dt><dfn>selectionBounds</dfn>, of type {{DOMRect}}</dt>
-            <dd>Initially 0s. The bounding box of the selection. The offset of the rectangle is expressed relative to the origin of the associated element. If the selection is collapsed, this is the bounding box of the caret.</dd>
-
-            <dt><dfn>characterBoundsRangeStart</dfn>, of type {{unsigned long}}</dt>
-            <dd>Initially 0. The start position of the range where the character bounds are cached.</dd>
-
-            <dt><dfn>characterBounds()</dfn> method</dt>
-            <dd>Initially empty array.
-                <p>
-                  The method must follow these steps:
-                </p>
-                <ol>
-                  <li>
-                    If the EditContext is not activated, abort these steps.
-                  </li>
-                  <li>
-                    Return the cached character bounds. The offset of the rectangle is expressed relative to the origin of the associated element.
-                  </li>
-                </ol>
-            </dd>
-
-
-            <dt>
-                <dfn>updateSelection()</dfn> method
-            </dt>
-            <dd>
-                <p>
-                  The method must follow these steps:
-                </p>
-                <ol>
-                  <li>
-                    If the EditContext is not activated, abort these steps.
-                  </li>
-                  <li>
-                    If start > end, abort these steps.
-                  </li>
-                  <li>
-                    set {{EditContext/selectionStart}} to start
-                  </li>
-                  <li>
-                    set {{EditContext/selectionEnd}} to end
-                  </li>
-                </ol>
-            </dd>
-            <dt>
-                <dfn>updateSelectionBounds()</dfn> method
-            </dt>
-              <dd>
-                <p>
-                  The method must follow these steps:
-                </p>
-                <ol>
-                  <li>
-                    If the EditContext is not activated, abort these steps.
-                  </li>
-                  <li>
-                    set {{EditContext/selectionBounds}} to <i>selectoinBound</i>.
-                  </li>
-                </ol>
-              </dd>
-              <dt>
-                <dfn>updateControlBounds()</dfn> method
-            </dt>
-              <dd>
-                <p>
-                  The method must follow these steps:
-                </p>
-                <ol>
-                  <li>
-                    If the EditContext is not activated, abort these steps.
-                  </li>
-                  <li>
-                    set {{EditContext/controlBounds}} to <i>controlBounds</i>.
-                  </li>
-                </ol>
-              </dd>
-              <dt>
-                <dfn>updateCharacterBounds()</dfn> method
-            </dt>
-              <dd>
-                <p>
-                  The method must follow these steps:
-                </p>
-                <ol>
-                  <li>
-                    If the EditContext is not activated, abort these steps.
-                  </li>
-                  <li>
-                    Set {{EditContext/characterBoundsRangeStart}} to <i>rangeStart</i>.
-                  </li>
-                  <li>
-                    Set cached character bounds to <i>characterBounds</i>.
-                  </li>
-                </ol>
-              </dd>
-
-            <dt>
-                <dfn>updateText()</dfn> method
-            </dt>
-              <dd>
-                <p>
-                  The method must follow these steps:
-                </p>
-                <ol>
-                  <li>
-                    If the EditContext is not activated, abort these steps.
-                  </li>
-                  <li>
-                    Replace the string in the range of <i>rangeStart</i> and <i>rangeEnd</i> of {{EditContext/text}} with <i>text</i>.
-                  </li>
-                </ol>
-              </dd>
-
-            <dt><dfn>attachedElements()</dfn> method</dt>
-            <dd><p>The method returns elements that are associated with the EditContext.</p></dd>
-            <p class="issue">
-                should attachedElements() return elements that are removed from the tree? If yes, the EditContext will keep removed elements alive. If not, we probably shouldn't allow a disconnected element to associate with EditContext, otherwise, it would be confusing/unintuitive that we allow it but attachedElements returns empty.
-            </p>
-            
-            <dt><dfn>ontextupdate</dfn></dt>
-            <dd><p>The event handler for {{TextUpdateEvent}}.</p></dd>
-
-            <dt><dfn>oncharacterboundsupdate</dfn></dt>
-            <dd><p>The event handler for {{CharacterBoundsUpdateEvent}}.</p></dd>
-
-            <dt><dfn>ontextformatupdate</dfn></dt>
-            <dd><p>The event handler for {{TextFormatUpdateEvent}}.</p></dd>
-
-            <dt><dfn>oncompositionstart</dfn></dt>
-            <dd><p>The event handler for the <a href='https://w3c.github.io/uievents/#event-type-compositionstart'>compositionstart</a> event.</p></dd>
-
-            <dt><dfn>oncompositionend</dfn></dt>
-            <dd><p>The event handler for the <a href='https://w3c.github.io/uievents/#event-type-compositionend'>compositionend</a> event.</p></dd>
-        </dl>
-    </section>
-
     <section data-dfn-for="EditContextEvents">
-        <h2>EditContext events</h2>
+        <h2>EditContext Events</h2>
         <section>
-            <h3><dfn>TextUpdateEvent</dfn></h3>
+            <h3>TextUpdateEvent</h3>
             <pre class="idl"><xmp>dictionary TextUpdateEventInit : EventInit {
     unsigned long updateRangeStart;
     unsigned long updateRangeEnd;
@@ -808,7 +787,7 @@ interface TextUpdateEvent : Event {
             </dl>
         </section>
         <section>
-            <h3><dfn>TextFormatUpdateEvent</dfn></h3>
+            <h3>TextFormatUpdateEvent</h3>
             <pre class="idl"><xmp>dictionary TextFormatInit {
     unsigned long rangeStart;
     unsigned long rangeEnd;
@@ -877,7 +856,7 @@ interface TextFormatUpdateEvent : Event {
             </dl>
         </section>
         <section>
-            <h3><dfn>CharacterBoundsUpdateEvent</dfn></h3>
+            <h3>CharacterBoundsUpdateEvent</h3>
             <pre class="idl"><xmp>dictionary CharacterBoundsUpdateEventInit : EventInit {
     unsigned long rangeStart;
     unsigned long rangeEnd;

--- a/native_selection_demo.html
+++ b/native_selection_demo.html
@@ -10,7 +10,7 @@
 <script>
     var editContext = new EditContext();
     editView.editContext = editContext;
-    editContext.text = editView.textContent;
+    editContext.updateText(0, 0, editView.textContent);
 
     let compositionNode = null;
     let compositionStartOffset = null
@@ -64,7 +64,8 @@
             controlBound = scaleDOMRect(controlBound, window.devicePixelRatio);
             let selectionBound = s.getRangeAt(0).getBoundingClientRect();
             selectionBound = scaleDOMRect(selectionBound, window.devicePixelRatio);
-            editContext.updateBounds(controlBound, selectionBound);
+            editContext.updateSelectionBounds(selectionBound);
+            editContext.updateControlBounds(controlBound);
 
             // Update decoration
             let range = document.createRange();
@@ -93,12 +94,44 @@
 
     document.addEventListener("selectionchange", e => {
         let s = document.getSelection();
-        console.log(`selectionchange:[anchorNode: ${s.anchorNode}: ${s.anchorOffset}], focusNode: ${s.focusNode}: ${s.focusOffset}]`);
+        console.log(`selectionchange: activeElement id(${document.activeElement.id}), [anchorNode: ${s.anchorNode}: ${s.anchorOffset}], focusNode: ${s.focusNode}: ${s.focusOffset}]`);
+        if (document.activeElement != editView)
+            return;
         // Update editContext using start/end info from the native selection. (here we assume anchor/focus node are the same)
         start = Math.min(s.anchorOffset, s.focusOffset);
         end = Math.max(s.anchorOffset, s.focusOffset);
         editContext.updateSelection(start, end);
         console.log('editContext.text[' + printEditContextBuffer() + ']');
+    });
+
+    function computeCharacterBound(offset) {
+        let range = document.createRange();
+        range.setStart(compositionNode, offset);
+        range.setEnd(compositionNode, offset + 1); // 1 character
+        return range.getBoundingClientRect();
+    }
+
+    editContext.addEventListener("characterboundsupdate", e => {
+        console.log(`editcontext.text:[${editContext.text}]`);
+        console.log(`characterboundsupdate: composition range (${e.rangeStart}, ${e.rangeEnd})`);
+        let rangeStart = e.rangeStart;
+        let rangeEnd = e.rangeEnd;
+
+        // Calculate bounds for each character in the range.
+        if (rangeEnd > rangeStart) {
+            let charBounds = [];
+            for (offset = rangeStart; offset < rangeEnd; offset++) {
+                let bound = computeCharacterBound(offset);
+                bound = scaleDOMRect(bound, window.devicePixelRatio);
+                charBounds.push(bound);
+            }
+            editContext.updateCharacterBounds(rangeStart, charBounds);
+
+            console.log("charcterBoundsRangeStart:");
+            console.log(editContext.characterBoundsRangeStart);
+            console.log("charcterBounds:");
+            console.log(editContext.characterBounds());
+        }
     });
 
     // To handle zoom levels


### PR DESCRIPTION
This PR adds more details to the spec and addresses 
#16 EditContext: event constructors are wrong
#18 EditContext: should editContext be on Element?
#24 EditContext.isInComposition should be renamed to `isComposing`
#29 "Squiggle" should be "Wavy" as a value of underlineStyle of TextFormat · Issue #29 · w3c/edit-context · GitHub
#32 Typo in "Extensions to the Element interface"

@BoCupp-Microsoft 