### PR TITLE
Remove confusing part of sentence defining active EditContexts.

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,7 +152,7 @@
                 [=Editing host=] may not be the best term to use to describe the impact of associating an {{EditContext}} with an {{HTMLElement}}.
                 It has similarities, such as making the {{HTMLElement}} the target for input events, but also differences in that the content of the [=editing host=] is not changed as a result of that input.
             </p>
-            <p>A user agent should have at most one <dfn>active EditContext</dfn>.  An {{EditContext}} is active when its associated element, or a descendant of its associated element, for which it is an [=editing host=], is <a href="https://html.spec.whatwg.org/multipage/interaction.html#focused">focused</a>.</p>
+            <p>A user agent should have at most one <dfn>active EditContext</dfn>.  An {{EditContext}} is active when its associated element, or a descendant of its associated element, is <a href="https://html.spec.whatwg.org/multipage/interaction.html#focused">focused</a>.</p>
             <p>When an {{EditContext}} meets the criteria above, it must be made the [=active EditContext=] by running the steps to [=activate an EditContext=].</p>
             <p>If an element associated with an [=active EditContext=] no longer meets the criteria outlined above, run the steps to [=deactivate an EditContext=].</p>
 


### PR DESCRIPTION
This sentence is confusing: “An EditContext is active when its associated element, or a descendant of its associated element, for which it is an [editing host](https://html.spec.whatwg.org/multipage/interaction.html#editing-host), is [focused](https://html.spec.whatwg.org/multipage/interaction.html#focused).”

It seems to imply that the `EditContext`, rather than the associated element, is the editing host. Delete the misleading part of the sentence since it's clarified elsewhere that EditContext-associated elements become editing hosts.

Pointed out by @annevk in #20.