### PR TITLE
Remove mention of 'parallel' from 'Update the Text Edit Context'

### DIFF
--- a/index.html
+++ b/index.html
@@ -646,16 +646,15 @@
         <dd>None</dd>
     </dl>
     <ol>
-        <li>let editContext be the currently [=active EditContext=].</li>
-        <li>If editContext is null, abort these steps.</li>
-        <li>If editContext's [=dirty flag=] is false, abort these steps.</li>
-        <li>If editContext's [=character bounds updated flag=] is false, run the steps to [=Dispatch character bounds update event=].</li>
-        <li>If the [=active EditContext=] is no longer editContext, abort these steps.</li>
-        <li>let textState be editContext's [=text state=].</li>
-        <li>In parallel, update the [=Text Edit Context=]'s [=text state=] to match the values in textState.</li>
+        <li>Let |editContext| be the currently [=active EditContext=].</li>
+        <li>If |editContext| is null, abort these steps.</li>
+        <li>If |editContext|'s [=dirty flag=] is false, abort these steps.</li>
+        <li>If |editContext|'s [=character bounds updated flag=] is false, run the steps to [=Dispatch character bounds update event=].</li>
+        <li>If the [=active EditContext=] is no longer |editContext|, abort these steps.</li>
+        <li>Update the [=Text Edit Context=]'s [=text state=] to match the values in |editContext|'s [=text state=].</li>
     </ol>
     <p class="note">
-        Note the steps to update the [=Text Edit Context=]'s [=text state=] to match the values in textState is dependent on the nature of the abstraction created over a platform-specific [=Text Input Service=].
+        Note that the steps to update the [=Text Edit Context=]'s [=text state=] are dependent on the nature of the abstraction created over a platform-specific [=Text Input Service=].
         Those details are not part of this specification.
     </p>
 </div><!-- algorithm -->


### PR DESCRIPTION
The steps to `Update the Text Edit Context` state that the changes to the `Text Edit Context`'s state should happen "in parallel", which is ill-defined.

In practice, browsers will likely update some parts of this state asynchronously. E.g. updates may happen synchronously in a render process and then be pushed asynchronously to a top-level browser process. But these details are explicitly out-of-scope for this spec, and will differ across implementations.

So, remove the mention of "in parallel" to defer the details of the update to implementations.

Also, ensure that variables are marked up properly.

Resolves #41.