### PR TITLE
Fix event firing to match arguments expected by `fire an event`

### DIFF
--- a/index.html
+++ b/index.html
@@ -604,7 +604,7 @@
                 <li>
                     If |text| is not empty and [=is composing=] is false
                     <ol>
-                        <li>[=Fire an event=] named <a href="https://w3c.github.io/uievents/#event-type-compositionstart">compositionstart</a> using {{CompositionEvent}} at the activated {{EditContext}}.
+                        <li>[=Fire an event=] named <a href="https://w3c.github.io/uievents/#event-type-compositionstart">compositionstart</a> at the [=active EditContext=] using {{CompositionEvent}}.
                         </li>
                         <li>set [=is composing=] to true</li>
                     </ol>
@@ -671,7 +671,7 @@
             </dl>
     <ol>
         <li>
-            [=Fire an event=] named "textupdate" using {{TextUpdateEvent}}, with
+            [=Fire an event=] named "textupdate" at the [=active EditContext=] using {{TextUpdateEvent}}, with
             {{TextUpdateEvent/text}} initialized to |text|,
             {{TextUpdateEvent/compositionStart}} initialized to [=composition start=],
             {{TextUpdateEvent/compositionEnd}} initialized to [=composition end=],
@@ -708,7 +708,7 @@
         </ol>
     </li>
     <li>
-        [=Fire an event=] named "textformatupdate" at the activated EditContext using {{TextFormatUpdateEvent}} with
+        [=Fire an event=] named "textformatupdate" at the [=active EditContext=] using {{TextFormatUpdateEvent}} with
         the {{TextFormatUpdateEvent}}'s [=text format list=] initialized to |formats|.
     </li>
 </ol>
@@ -724,7 +724,7 @@
     </dl>
 <ol>
 <li>
-    [=Fire an event=] named "characterboundsupdate" using {{CharacterBoundsUpdateEvent}} with
+    [=Fire an event=] named "characterboundsupdate" at the [=active EditContext=] using {{CharacterBoundsUpdateEvent}} with
     {{CharacterBoundsUpdateEvent/rangeStart}} initialized to [=composition start=] and
     {{CharacterBoundsUpdateEvent/rangeEnd}} initialized to [=composition end=].
 </li>

--- a/index.html
+++ b/index.html
@@ -706,7 +706,10 @@
             <li>Add |textFormat| to |formats|</li>
         </ol>
     </li>
-    <li> [=Fire an event=] named "textformatupdate" at the activated EditContext using {{TextFormatUpdateEvent}} with |formats|</li>
+    <li>
+        [=Fire an event=] named "textformatupdate" at the activated EditContext using {{TextFormatUpdateEvent}} with
+        the {{TextFormatUpdateEvent}}'s [=text format list=] initialized to |formats|.
+    </li>
 </ol>
 </div><!-- algorithm -->
 
@@ -1077,8 +1080,9 @@ interface TextFormatUpdateEvent : Event {
                 <dd>The {{TextFormat/underlineColor}} getter steps are to return [=this=]'s [=underlineColor=].</dd>
                 <dt>{{TextFormatUpdateEvent/getTextFormats}} method
                 </dt>
-                <dd>Returns [=this=]'s cached [=text formats=].</dd>
+                <dd>Returns [=this=]'s [=text format list=].</dd>
             </dl>
+            <p>A {{TextFormatUpdateEvent}} has an associated <dfn>text format list</dfn>, a list of zero or more [=text format=]s.</p>
         </section>
         <section>
             <h3>CharacterBoundsUpdateEvent</h3>

--- a/index.html
+++ b/index.html
@@ -43,7 +43,8 @@
           , xref: ["WebIDL"
           , "DOM"
           , "HTML"
-          , "geometry-1"]
+          , "geometry-1"
+          , "uievents"]
         };
     </script>
 </head>

--- a/index.html
+++ b/index.html
@@ -603,7 +603,7 @@
                 <li>
                     If |text| is not empty and [=is composing=] is false
                     <ol>
-                        <li>[=Fire an event=] named "compositionstart" at the activated {{EditContext}}.
+                        <li>[=Fire an event=] named <a href="https://w3c.github.io/uievents/#event-type-compositionstart">compositionstart</a> using {{CompositionEvent}} at the activated {{EditContext}}.
                         </li>
                         <li>set [=is composing=] to true</li>
                     </ol>
@@ -670,9 +670,13 @@
             </dl>
     <ol>
         <li>
-            Let |event| be a new {{TextUpdateEvent}} with |text|, [=composition start=], [=composition end=], [=selection start=], and [=selection end=]
+            [=Fire an event=] named "textupdate" using {{TextUpdateEvent}}, with
+            {{TextUpdateEvent/text}} initialized to |text|,
+            {{TextUpdateEvent/compositionStart}} initialized to [=composition start=],
+            {{TextUpdateEvent/compositionEnd}} initialized to [=composition end=],
+            {{TextUpdateEvent/selectionStart}} initialized to [=selection start=], and
+            {{TextUpdateEvent/selectionEnd}} initialized to [=selection end=].
         </li>
-        <li> [=Fire an event=] named "textupdate" with |event|</li>
     </ol>
     </div><!-- algorithm -->
 
@@ -716,9 +720,10 @@
     </dl>
 <ol>
 <li>
-    Let |event| be a new {{CharacterBoundsUpdateEvent}} with [=composition start=] and [=composition end=]
+    [=Fire an event=] named "characterboundsupdate" using {{CharacterBoundsUpdateEvent}} with
+    {{CharacterBoundsUpdateEvent/rangeStart}} initialized to [=composition start=] and
+    {{CharacterBoundsUpdateEvent/rangeEnd}} initialized to [=composition end=].
 </li>
-<li> [=Fire an event=] named "characterboundsupdate" with |event|</li>
 </ol>
 </div><!-- algorithm -->
 


### PR DESCRIPTION
Change event firing to use the right event constructors and follow normal conventions for initializing event fields.

While working on this I noticed that `TextFormatUpdateEvent.getFormats()` doesn't reference any internal state, and instead implies that it's returning the EditContext's text formats. Fixed this by adding an internal text format list to the event that's initialized during firing.

Thanks @dontcallmedom for initially raising this in https://github.com/w3c/edit-context/pull/31. Unfortunately the locations fixed there have all moved and changed, so I started a new PR.

Resolves #42 .