### PR TITLE
Remove issue about multiple associated elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,10 +153,6 @@
                 the {{EditContext}} to the element's {{HTMLElement/editContext}} property.
                 An {{HTMLElement}} can be <a data-lt="associated element">associated</a> with at most one {{EditContext}}.
             </p>
-            <p class="issue">
-                Should we enable authors to <a data-lt="associated element">associate</a> an {{EditContext}} with multiple elements?
-                This could be useful for multipage editing scenarios where different pages are represented by different elements in the DOM.
-            </p>
             <p>
                 The definition of an [=editing host=] will be modified so that an {{EditContext}}'s
                 <a>associated element</a> is also an [=editing host=], unless that element's parent is
@@ -1074,7 +1070,7 @@ interface EditContext : EventTarget {
             <dt>attachedElements() method</dt>
             <dd><p>The method returns a list with one item which is the the {{EditContext}}'s <a>associated element</a>, or an empty list if the {{EditContext}}'s <a>associated element</a> is null.</p></dd>
             <p class="note">
-                This method returns a list instead of a single element for forward compatibility if in the future grant the ability for an {{EditContext}} to have multiple <a>associated elements</a>.
+                This method returns a list instead of a single element for forward compatibility if {{EditContext}} is ever granted the ability to have multiple <a>associated elements</a>.
             </p>
             <p class="issue">
                 Should attachedElements() return elements that are removed from the tree? If yes, the EditContext will keep removed elements alive. If not, we probably shouldn't allow a disconnected element to <a data-lt="associated element">associate</a> with EditContext, otherwise, it would be confusing/unintuitive that we allow it but attachedElements returns empty.


### PR DESCRIPTION
Remove issue about support for multiple associated elements since we resolved in https://github.com/w3c/edit-context/issues/50 not to do this for now.

Also fix wording in the note about `attachedElements()`.

Closes https://github.com/w3c/edit-context/issues/50.