### PR TITLE
Fix compositionend links

### DIFF
--- a/index.html
+++ b/index.html
@@ -701,7 +701,7 @@
                                 <li>Set |editContext|'s [=is composing=] to false.</li>
                                 <li>
                                     [=Fire an event=] named
-                                    <a href="https://w3c.github.io/uievents/#event-type-compositionstart">compositionend</a>
+                                    <a href="https://w3c.github.io/uievents/#event-type-compositionend">compositionend</a>
                                     at |editContext| using {{CompositionEvent}}.
                                 </li>
                                 <li>Return.</li>
@@ -735,7 +735,7 @@
                                 <li>Set |editContext|'s [=is composing=] to false.</li>
                                 <li>
                                     [=Fire an event=] named
-                                    <a href="https://w3c.github.io/uievents/#event-type-compositionstart">compositionend</a>
+                                    <a href="https://w3c.github.io/uievents/#event-type-compositionend">compositionend</a>
                                     at |editContext| using {{CompositionEvent}}.
                                 </li>
                             </ol>


### PR DESCRIPTION
Before seeing @dontcallmedom 's fix at https://github.com/w3c/edit-context/pull/63 I introduced a couple more instances of the issue.

Fixing the remaining links.