### PR TITLE
Change attachedElements() to return list of HTMLElement

### DIFF
--- a/index.html
+++ b/index.html
@@ -964,7 +964,7 @@ interface EditContext : EventTarget {
     undefined updateSelectionBounds(DOMRect selectionBounds);
     undefined updateCharacterBounds(unsigned long rangeStart, sequence<DOMRect> characterBounds);
 
-    sequence<Element> attachedElements();
+    sequence<HTMLElement> attachedElements();
 
     readonly attribute DOMString text;
     readonly attribute unsigned long selectionStart;


### PR DESCRIPTION
Change `EditContext.attachedElements()`s to return `sequence<HTMLElement>` instead of `sequence<Element>`, to align with the fact that the API to associated an EditContext with an element is on `HTMLElement`.

Closes #68.