### PR TITLE
Remove 'is active' checks from EditContext setters

### DIFF
--- a/index.html
+++ b/index.html
@@ -998,9 +998,6 @@ interface EditContext : EventTarget {
                 </dl>
                 <ol>
                     <li>
-                        If [=this=] is not activated, abort these steps.
-                    </li>
-                    <li>
                         Replace the substring of [=text=] in the range of |rangeStart| and |rangeEnd| with |newText|
                     </li>
                     <li>
@@ -1023,9 +1020,6 @@ interface EditContext : EventTarget {
                         <dd>None</dd>
                     </dl>
                     <ol>
-                        <li>
-                            If [=this=] is not activated, abort these steps.
-                        </li>
                         <li>
                             If |start| > |end|, abort these steps.
                         </li>
@@ -1052,9 +1046,6 @@ interface EditContext : EventTarget {
                     </dl>
                     <ol>
                         <li>
-                            If [=this=] is not activated, abort these steps.
-                        </li>
-                        <li>
                             set [=selection bounds=] to |selectionBounds|
                         </li>
                     </ol>
@@ -1073,9 +1064,6 @@ interface EditContext : EventTarget {
                         <dd>None</dd>
                     </dl>
                     <ol>
-                        <li>
-                            If [=this=] is not activated, abort these steps.
-                        </li>
                         <li>
                             set [=control bounds=] to |controlBounds|
                         </li>
@@ -1096,9 +1084,6 @@ interface EditContext : EventTarget {
                         <dd>None</dd>
                     </dl>
                     <ol>
-                        <li>
-                            If [=this=] is not activated, abort these steps.
-                        </li>
                         <li>
                             set [=start index=] to |rangeStart|.
                         </li>


### PR DESCRIPTION
Per [WG resolution](https://github.com/w3c/edit-context/issues/26#issuecomment-1762000956), remove "is active" checks from `updateText()`, `updateSelection()`, `updateSelectionBounds()`, `updateControlBounds()`, and `updateCharacterBounds()`.

Closes #26 