### PR TITLE
Remove secure context requirement

### DIFF
--- a/index.html
+++ b/index.html
@@ -1226,17 +1226,6 @@ interface CharacterBoundsUpdateEvent : Event {
             </dl>
         </section>
     </section>
-    <section>
-        <h2>Privacy and Security Considerations</h2>
-        <p>To mitigate potential security and privacy risks, browsers are expected to follow best practices described below.</p>
-            <p>
-                <ul>
-                    <li>
-                        User Agent MUST only allow {{EditContext/updateSelection()}}, {{EditContext/updateText()}}, {{EditContext/updateSelectionBounds()}}, {{EditContext/updateControlBounds()}}, and {{EditContext/updateCharacterBounds()}} methods to be called in a <a href="https://w3c.github.io/webappsec-secure-contexts/">Secure Context</a>.
-                    </li>
-                </ul>
-            </p>
-    </section>
     <section id="idl-index" class="appendix">
         <!-- All the Web IDL will magically appear here -->
     </section>


### PR DESCRIPTION
In https://github.com/w3c/edit-context/issues/11#issuecomment-1719910680 we resolved that EditContext need not require a secure context. Remove the part of the spec contradicting this.