### PR TITLE
Remove 'double' UnderlineStyle

### DIFF
--- a/index.html
+++ b/index.html
@@ -1191,7 +1191,7 @@ interface TextUpdateEvent : Event {
         </section>
         <section>
             <h3>TextFormatUpdateEvent</h3>
-            <pre class="idl"><xmp>enum UnderlineStyle { "none", "solid", "double", "dotted", "dashed", "wavy" };
+            <pre class="idl"><xmp>enum UnderlineStyle { "none", "solid", "dotted", "dashed", "wavy" };
 enum UnderlineThickness { "none", "thin", "thick" };
 
 dictionary TextFormatInit {


### PR DESCRIPTION
The `double` UnderlineStyle was added in anticipation of a planned Windows feature that never came to be. There are no other known uses, so remove it.

Closes #89