### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,10 +2,12 @@
 
 For normative changes, the following tasks have been completed:
  * [ ] Editing WG resolution on the proposed changes
+
  * [ ] For features that have not shipped in all browsers, at least two implementers are interested (link to issue indicating position, or write "Implementing"/"Not Implementing"):
    * [ ] WebKit
    * [ ] Chromium
    * [ ] Gecko
+
  * [ ] For browsers that are shipping the feature, implementation bugs are filed for the proposed changes (link to bug, or write "Implementing"/"Not Implementing"):
    * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
    * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,7 @@
 <!-- Please fill in the sections below when making normative changes. Feel free to remove the sections when only making non-normative changes. -->
 
 For normative changes, the following tasks have been completed:
- * [ ] Editing WG resolution on the proposed changes
-
- * [ ] For features that have not shipped in all browsers, at least two implementers are interested (link to issue indicating position, or write "Implementing"/"Not Implementing"):
+ * [ ] Editing WG resolution on the proposed changes, with at least two implementers participating and not objecting:
    * [ ] WebKit
    * [ ] Chromium
    * [ ] Gecko

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,8 @@
 For normative changes, the following tasks have been completed:
  * [ ] At least two implementers are interested:
-   * …
-   * …
+   * [ ] WebKit
+   * [ ] Chromium
+   * [ ] Gecko
  * [ ] Editing WG resolution on the proposed changes
 
 Implementation bugs are filed:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,14 @@
 <!-- Please fill in the sections below when making normative changes. Feel free to remove the sections when only making non-normative changes. -->
 
 For normative changes, the following tasks have been completed:
- * [ ] At least two implementers are interested:
+ * [ ] Editing WG resolution on the proposed changes
+
+ * [ ] Implementation interest for features that have yet to be shipped in all browsers (link to issue, or write "Implementing" or "Not Implementing"):
    * [ ] WebKit
    * [ ] Chromium
    * [ ] Gecko
- * [ ] Editing WG resolution on the proposed changes
 
-Implementation bugs are filed:
- * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
- * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
- * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)
+ * [ ] Implementation bugs for browsers that are shipping the feature:
+   * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
+   * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
+   * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+For normative changes, the following tasks have been completed:
+ * [ ] At least two implementers are interested:
+   * …
+   * …
+ * [ ] Editing WG resolution on the proposed changes
+
+Implementation bugs are filed:
+ * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
+ * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
+ * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+<!-- Please fill in the sections below when making normative changes. Feel free to remove the sections when only making non-normative changes. -->
+
 For normative changes, the following tasks have been completed:
  * [ ] At least two implementers are interested:
    * [ ] WebKit

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@ For normative changes, the following tasks have been completed:
    * [ ] Chromium
    * [ ] Gecko
 
- * [ ] For browsers that are shipping the feature, implementation bugs are filed for the proposed changes (link to bug, or write "Implementing"/"Not Implementing"):
+ * [ ] For browsers that are shipping the feature, implementation bugs are filed for the proposed changes (link to bug, or write "Not Implementing"):
    * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
    * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
    * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,13 +2,11 @@
 
 For normative changes, the following tasks have been completed:
  * [ ] Editing WG resolution on the proposed changes
-
- * [ ] Implementation interest for features that have yet to be shipped in all browsers (link to issue, or write "Implementing" or "Not Implementing"):
+ * [ ] For features that have not shipped in all browsers, at least two implementers are interested (link to issue indicating position, or write "Implementing"/"Not Implementing"):
    * [ ] WebKit
    * [ ] Chromium
    * [ ] Gecko
-
- * [ ] Implementation bugs for browsers that are shipping the feature:
+ * [ ] For browsers that are shipping the feature, implementation bugs are filed for the proposed changes (link to bug, or write "Implementing"/"Not Implementing"):
    * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
    * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
    * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


### PR DESCRIPTION
This PR introduces a PR template that all subsequent changes into this repo should use, as per resolution to https://github.com/w3c/editing/issues/463. Once finalized, this template will be added to other Editing WG repos as well.