### PR TITLE
Specify inputTypes handled by EditContext

### DIFF
--- a/index.html
+++ b/index.html
@@ -733,6 +733,30 @@
                 </ol>
             </div><!-- algorithm -->
 
+            <h4><dfn>EditContext-handled inputType</dfn></h4>
+            <div class="algorithm">
+                An <a href="https://www.w3.org/TR/uievents/#dom-inputevent-inputtype">inputType</a> is an
+                [=EditContext-handled inputType=] if it is one of the following:
+                <ul>
+                    <li><code>insertText</code></li>
+                    <li><code>insertTranspose</code></li>
+                    <li><code>deleteWordBackward</code></li>
+                    <li><code>deleteWordForward</code></li>
+                    <li><code>deleteContent</code></li>
+                    <li><code>deleteContentBackward</code></li>
+                    <li><code>deleteContentForward</code></li>
+                </ul>
+                <div class="note">
+                    The <a href="https://www.w3.org/TR/uievents/#dom-inputevent-inputtype">inputType</a>s handled by {{EditContext}}
+                    are those which operate only on raw text. Other <a href="https://www.w3.org/TR/uievents/#dom-inputevent-inputtype">inputType</a>s
+                    that depend on formats, clipboard/dragdrop, undo, or browser UI like spellcheck cannot be handled by
+                    {{EditContext}} since {{EditContext}}'s state does not include these concepts. If an author wants their
+                    application to handle those <a href="https://www.w3.org/TR/uievents/#dom-inputevent-inputtype">inputType</a>s
+                    they need to process them manually in a <a href="https://www.w3.org/TR/uievents/#event-type-beforeinput">beforeinput</a>
+                    event handler.
+                </div>
+            </div>
+
             <h4><dfn>Update the EditContext</dfn></h4>
             <div class="algorithm">
                 <dl>

--- a/index.html
+++ b/index.html
@@ -751,7 +751,7 @@
                     are those which operate only on raw text. Other <a href="https://www.w3.org/TR/uievents/#dom-inputevent-inputtype">inputType</a>s
                     that depend on formats, clipboard/dragdrop, undo, or browser UI like spellcheck cannot be handled by
                     {{EditContext}} since {{EditContext}}'s state does not include these concepts. If an author wants their
-                    application to handle those <a href="https://www.w3.org/TR/uievents/#dom-inputevent-inputtype">inputType</a>s
+                    application to handle those <a href="https://www.w3.org/TR/uievents/#dom-inputevent-inputtype">inputType</a>s,
                     they need to process them manually in a <a href="https://www.w3.org/TR/uievents/#event-type-beforeinput">beforeinput</a>
                     event handler.
                 </div>


### PR DESCRIPTION
Define the set of `inputType`s that will be "handled" by [Handle Input For EditContext](https://w3c.github.io/edit-context/#handle-input-for-editcontext).

See also https://github.com/w3c/input-events/pull/154

For normative changes, the following tasks have been completed:

 * [X] Editing WG resolution on the proposed changes, with at least two implementers participating and not objecting: https://github.com/w3c/edit-context/issues/94#issuecomment-2102931139
   * [X] WebKit
   * [X] Chromium
   * [X] Gecko

 * [X] For browsers that are shipping the feature, implementation bugs are filed for the proposed changes (link to bug, or write "Implementing"/"Not Implementing"):
   * [X] WebKit: Not Implementing (https://bugs.webkit.org/show_bug.cgi?id=269922)
   * [X] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=348590031)
   * [X] Gecko: Not Implementing (https://bugzilla.mozilla.org/show_bug.cgi?id=1904161)

Closes #94.