### PR TITLE
Maintain selection and composition during updateText()

### DIFF
--- a/index.html
+++ b/index.html
@@ -1058,9 +1058,27 @@ interface EditContext : EventTarget {
                 </dl>
                 <ol>
                     <li>
-                        Replace the substring of [=text=] in the range of |rangeStart| and |rangeEnd| with |newText|
-                        <div class="note">It's permissible that |rangeStart| > |rangeEnd|. The substring between the indices should be replaced in the same way as when |rangeStart| <= |rangeEnd|.</div>
+                        If |rangeStart| > |rangeEnd|, then swap the values of |rangeStart| and |rangeEnd|.
                     </li>
+                    <li>
+                        Replace the substring of [=text=] in the range of |rangeStart| and |rangeEnd| with |newText|.
+                    </li>
+                    <li>
+                        If [=selection start=] is greater than |rangeEnd|, then set [=selection start=] to [=selection start=] plus the length of |newText| minus (|rangeEnd| minus |rangeStart|).
+                    </li>
+                    <li>
+                        If [=selection start=] is less greater than |rangeStart| and less than |rangeEnd|, then set [=selection start=] to |rangeStart| plus the length of |newText|.
+                    </li>
+                    <li>
+                        If [=selection end=] is greater than |rangeEnd|, then set [=selection end=] to [=selection end=] plus the length of |newText| minus (|rangeEnd| minus |rangeStart|).
+                    </li>
+                    <li>
+                        If [=selection end=] is less greater than |rangeStart| and less than |rangeEnd|, then set [=selection end=] to |rangeStart| plus the length of |newText|.
+                    </li>
+                    <p class="note">
+                        In other words, both selection boundary points are updated such that if they were after the affected range, they're offset by the overall change to the text length. If they were within the affected range, they're moved to the end of the new text.
+                        If they were before the affected range, they're left unchanged.
+                    </p>
                 </ol>
             </div>
             </dd>

--- a/index.html
+++ b/index.html
@@ -1119,10 +1119,13 @@ interface EditContext : EventTarget {
                     </dl>
                     <ol>
                         <li>
-                            set [=selection start=] to |start|
+                            If [=selection start=] is not equal to |start| or [=selection end=] is not equal to |end|, then set [=is composing=] to false.
                         </li>
                         <li>
-                            set [=selection end=] to |end|
+                            Set [=selection start=] to |start|.
+                        </li>
+                        <li>
+                            Set [=selection end=] to |end|.
                         </li>
                     </ol>
                 </div>

--- a/index.html
+++ b/index.html
@@ -1067,18 +1067,40 @@ interface EditContext : EventTarget {
                         If [=selection start=] is greater than |rangeEnd|, then set [=selection start=] to [=selection start=] plus the length of |newText| minus (|rangeEnd| minus |rangeStart|).
                     </li>
                     <li>
-                        If [=selection start=] is less greater than |rangeStart| and less than |rangeEnd|, then set [=selection start=] to |rangeStart| plus the length of |newText|.
+                        If [=selection start=] is greater than |rangeStart| and less than |rangeEnd|, then set [=selection start=] to |rangeStart| plus the length of |newText|.
                     </li>
                     <li>
                         If [=selection end=] is greater than |rangeEnd|, then set [=selection end=] to [=selection end=] plus the length of |newText| minus (|rangeEnd| minus |rangeStart|).
                     </li>
                     <li>
-                        If [=selection end=] is less greater than |rangeStart| and less than |rangeEnd|, then set [=selection end=] to |rangeStart| plus the length of |newText|.
+                        If [=selection end=] is greater than |rangeStart| and less than |rangeEnd|, then set [=selection end=] to |rangeStart| plus the length of |newText|.
                     </li>
                     <p class="note">
                         In other words, both selection boundary points are updated such that if they were after the affected range, they're offset by the overall change to the text length. If they were within the affected range, they're moved to the end of the new text.
                         If they were before the affected range, they're left unchanged.
                     </p>
+                    <li>
+                        If [=is composing=] is true, then:
+                        <ol>
+                            <li>
+                                If min([=composition start=], [=composition end=]) is less than |rangeEnd| and max([=composition start=], [=composition end=]) is greater than |rangeStart|, then:
+                                <ol>
+                                    <li>Set [=is composing=] to false.</li>
+                                </ol>
+                            </li>
+                            <li>
+                                Otherwise:
+                                <ol>
+                                    <li>
+                                        If [=composition start=] is greater than |rangeEnd|, then set [=composition start=] to [=composition start=] plus the length of |newText| minus (|rangeEnd| minus |rangeStart|).
+                                    </li>
+                                    <li>
+                                        If [=composition end=] is greater than |rangeEnd|, then set [=composition end=] to [=composition end=] plus the length of |newText| minus (|rangeEnd| minus |rangeStart|).
+                                    </li>
+                                </ol>
+                            </li>
+                        </ol>
+                    </li>
                 </ol>
             </div>
             </dd>


### PR DESCRIPTION
Make the following changes to keep the selection and composition in a consistent state after `updateText()`/`updateSelection()` calls.

- For each selection boundary point, `updateText()` sets the boundary point to `boundaryPoint + text.length - (rangeEnd - rangeStart)` when `boundaryPoint >= rangeEnd`, or to `rangeStart + text.length` when `boundaryPoint > rangeStart && boundaryPoint < rangeEnd`.
- When a composition is active during an `updateText()` call, 
  - If the updated range does not overlap with the composed range, move the composition position in the same way as for selection.
  - If it does overlap, abort the composition.
- When a composition is active when `updateSelection()` is called with a selection that differs from the current selection, abort the composition.

Resolves https://github.com/w3c/edit-context/issues/111.

For normative changes, the following tasks have been completed:
 * [ ] Editing WG resolution on the proposed changes, with at least two implementers participating and not objecting:
   * [ ] WebKit
   * [ ] Chromium
   * [ ] Gecko

 * [ ] For browsers that are shipping the feature, implementation bugs are filed for the proposed changes (link to bug, or write "Not Implementing"):
   * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
   * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
   * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)
