### PR TITLE
Add differences for composition events and canvas element

### DIFF
--- a/index.html
+++ b/index.html
@@ -258,6 +258,11 @@
                         event as specified in [[uievents]].
                     </li>
                     <li>
+                        When the {{Document}} being edited has an [=active EditContext=], the user agent must not fire the
+                        <a href="https://www.w3.org/TR/uievents/#events-compositionevents">composition events</a> against the
+                        <a>EditContext editing host</a>, instead they must be fired against the {{EditContext}}.
+                    </li>
+                    <li>
                         When a <code>&lt;canvas&gt;</code> element is used as the [=associated element=], the browser's spellcheck
                         cannot be used, and the author has to implement selection and caret navigation.
                     </li>

--- a/index.html
+++ b/index.html
@@ -234,7 +234,8 @@
                         Each child node of the <a>EditContext editing host</a> becomes <a href="https://w3c.github.io/editing/docs/execCommand/#editable">editable</a>,
                         unless that node has a [^html-global/contenteditable^] attribute set to "<code>false</code>".
                     </li>
-                    <li>The user agent handles focus and caret navigation for any editable element in the <a>EditContext editing host</a>.</li>
+                    <li>The user agent handles focus and caret navigation for any editable element in the <a>EditContext editing host</a> (except when the
+                        [=associated element=] is a [=canvas=]; see below in this section).</li>
                     <li>
                         The <a>EditContext editing host</a> receives key events and the <a href="https://www.w3.org/TR/uievents/#event-type-beforeinput">beforeinput</a>
                         event as specified in [[uievents]].
@@ -258,13 +259,26 @@
                         event as specified in [[uievents]].
                     </li>
                     <li>
-                        When the {{Document}} being edited has an [=active EditContext=], the user agent must not fire the
+                        When the {{Document}} being edited has an [=active EditContext=], the user agent must not fire
                         <a href="https://www.w3.org/TR/uievents/#events-compositionevents">composition events</a> against the
-                        <a>EditContext editing host</a>, instead they must be fired against the {{EditContext}}.
+                        <a>EditContext editing host</a> as a direct result of user action. Instead they will be fired against the {{EditContext}} as part
+                        of [=update the EditContext|updating the EditContext=] or [=deactivate an EditContext|deactivating the EditContext=].
                     </li>
                     <li>
-                        When a <code>&lt;canvas&gt;</code> element is used as the [=associated element=], the browser's spellcheck
-                        cannot be used, and the author has to implement selection and caret navigation.
+                        <p>
+                            When the [=active EditContext=]'s [=associated element=] is a [=canvas=], there are further differences:
+                        </p>
+                        <ul>
+                            <li>
+                                The user agent is unable to handle caret navigation and selection since it doesn't have information
+                                about how text is laid out in the [=canvas=], so the author has to implement caret navigation and selection.
+                            </li>
+                            <li>
+                                The user agent is unable to present inline spelling and grammar suggestions since it doesn't have information
+                                about how the text is laid out in the [=canvas=], so if the author wants to support spelling and grammar suggestions,
+                                they have to implement that themselves.
+                            </li>
+                        </ul>
                     </li>
                 </ul>
             </div>

--- a/index.html
+++ b/index.html
@@ -257,6 +257,10 @@
                         against the <a>EditContext editing host</a> as a direct result of user action
                         event as specified in [[uievents]].
                     </li>
+                    <li>
+                        When a <code>&lt;canvas&gt;</code> element is used as the [=associated element=], the browser's spellcheck
+                        cannot be used, and the author has to implement selection and caret navigation.
+                    </li>
                 </ul>
             </div>
 


### PR DESCRIPTION
- Clarify that composition events are not fired on the editing host (they're fired on the EditContext instead).
- Clarify that when the editing host is a `<canvas>`, the UA can't handle selection/caret navigation/spelling and grammar checking.
<!-- Please fill in the sections below when making normative changes. Feel free to remove the sections when only making non-normative changes. -->

This is not really a normative change of behavior, but rather clarifying behavior that the spec left unclear.

Closes #72 
Closes #86.

 * [x] For browsers that are shipping the feature, implementation bugs are filed for the proposed changes (link to bug, or write "Not Implementing"):
   * [x] WebKit (https://github.com/WebKit/standards-positions/issues/243)
   * [x] Chromium (https://issues.chromium.org/issues/40642681)
   * [x] Gecko (https://github.com/mozilla/standards-positions/issues/199)
