### PR TITLE
Updates deactivate timing for old EditContext

### DIFF
--- a/index.html
+++ b/index.html
@@ -705,13 +705,16 @@
                                 [=active EditContext=], then run the steps to [=deactivate an EditContext=]
                                 with |oldEditContext|.
                             </li>
-                            <li>If |editContext| is not null, then set |editContext|'s <a>associated element</a> to [=this=].
-                            <li>If |oldEditContext| is not null, then:
-                                <ol>
-                                    <li>[=Assert=]: |oldEditContext|'s <a>associated element</a> is equal to [=this=].</li>
-                                    <li>Set |oldEditContext|'s <a>associated element</a> to null.</li>
-                                </ol>
+                            <li>
+                                If |oldEditContext| is not null and |oldEditContext|'s <a>associated element</a> is not equal to [=this=], then
+                                terminate these steps.
                             </li>
+                            <li>
+                                If |editContext| is not null, |editContext|'s <a>associated element</a> is not null and |editContext|'s
+                                <a>associated element</a> is not equal to [=this=], then [=exception/throw=] a {{"NotSupportedError"}} {{DOMException}}.
+                            </li>
+                            <li>If |oldEditContext| is not null, set |oldEditContext|'s <a>associated element</a> to null.</li>
+                            <li>If |editContext| is not null, then set |editContext|'s <a>associated element</a> to [=this=].
                             <li>Set [=this=]'s internal [[\EditContext]] slot to be |editContext|.</li>
                         </ol>
                     </div><!-- algorithm -->

--- a/index.html
+++ b/index.html
@@ -696,10 +696,16 @@
                                 <ol>
                                     <li>If |editContext|'s <a>associated element</a> is equal to [=this=], then terminate these steps.</li>
                                     <li>If |editContext|'s <a>associated element</a> is not null, then [=exception/throw=] a {{"NotSupportedError"}} {{DOMException}}.</li>
-                                    <li>Set |editContext|'s <a>associated element</a> to [=this=].</li>
                                 </ol>
                             </li>
                             <li>Let |oldEditContext| be the value of [=this=]'s internal [[\EditContext]] slot.</li>
+                            <li>
+                                If |oldEditContext| is not null and |oldEditContext| is [=this=]'s
+                                <a href="https://dom.spec.whatwg.org/#concept-node-document">node document</a>'s
+                                [=active EditContext=], then run the steps to [=deactivate an EditContext=]
+                                with |oldEditContext|.
+                            </li>
+                            <li>If |editContext| is not null, then set |editContext|'s <a>associated element</a> to [=this=].
                             <li>If |oldEditContext| is not null, then:
                                 <ol>
                                     <li>[=Assert=]: |oldEditContext|'s <a>associated element</a> is equal to [=this=].</li>
@@ -707,12 +713,6 @@
                                 </ol>
                             </li>
                             <li>Set [=this=]'s internal [[\EditContext]] slot to be |editContext|.</li>
-                            <li>
-                                If |oldEditContext| is not null and |oldEditContext| is [=this=]'s
-                                <a href="https://dom.spec.whatwg.org/#concept-node-document">node document</a>'s
-                                [=active EditContext=], then run the steps to [=deactivate an EditContext=]
-                                with |oldEditContext|.
-                            </li>
                         </ol>
                     </div><!-- algorithm -->
                 </dd>

--- a/index.html
+++ b/index.html
@@ -702,16 +702,17 @@
                             <li>
                                 If |oldEditContext| is not null and |oldEditContext| is [=this=]'s
                                 <a href="https://dom.spec.whatwg.org/#concept-node-document">node document</a>'s
-                                [=active EditContext=], then run the steps to [=deactivate an EditContext=]
-                                with |oldEditContext|.
-                            </li>
-                            <li>
-                                If |oldEditContext| is not null and |oldEditContext|'s <a>associated element</a> is not equal to [=this=], then
-                                terminate these steps.
-                            </li>
-                            <li>
-                                If |editContext| is not null, |editContext|'s <a>associated element</a> is not null and |editContext|'s
-                                <a>associated element</a> is not equal to [=this=], then [=exception/throw=] a {{"NotSupportedError"}} {{DOMException}}.
+                                [=active EditContext=], then:
+                                <ol>
+                                    <li>Run the steps to [=deactivate an EditContext=] with |oldEditContext|.</li>
+                                    <li>
+                                        If |oldEditContext|'s <a>associated element</a> is not equal to [=this=], then terminate these steps.
+                                    </li>
+                                    <li>
+                                        If |editContext| is not null, |editContext|'s <a>associated element</a> is not null and |editContext|'s
+                                        <a>associated element</a> is not equal to [=this=], then [=exception/throw=] a {{"NotSupportedError"}} {{DOMException}}.
+                                    </li>
+                                </ol>
                             </li>
                             <li>If |oldEditContext| is not null, set |oldEditContext|'s <a>associated element</a> to null.</li>
                             <li>If |editContext| is not null, then set |editContext|'s <a>associated element</a> to [=this=].


### PR DESCRIPTION
Move the "deactivate an EditContext" step earlier in the `HTMLElement.editContext` replacement algorithm so deactivation steps (e.g., compositionend) run while the EditContext is still associated with its element

Closes #75
<!-- Please fill in the sections below when making normative changes. Feel free to remove the sections when only making non-normative changes. -->

For normative changes, the following tasks have been completed:
 * [x] Editing WG resolution on the proposed changes, with at least two implementers participating and not objecting:
   * [x] WebKit
   * [x] Chromium
   * [x] Gecko

 * [x] For browsers that are shipping the feature, implementation bugs are filed for the proposed changes (link to bug, or write "Not Implementing"):
   * [x] WebKit (https://github.com/WebKit/standards-positions/issues/243)
   * [x] Chromium (https://issues.chromium.org/issues/40642681)
   * [x] Gecko (https://github.com/mozilla/standards-positions/issues/199)
