### PR TITLE
Add note for textformat underline styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -1282,6 +1282,11 @@ interface TextFormatUpdateEvent : Event {
                 <dd>Returns [=this=]'s [=text format list=].</dd>
             </dl>
             <p>A {{TextFormatUpdateEvent}} has an associated <dfn>text format list</dfn>, a list of zero or more [=text format=]s.</p>
+            <p class="note">
+              User agents can adjust the underline style or thickness before dispatching the {{TextFormatUpdateEvent}} 
+              to ensure proper contrast with the content or to mitigate fingerprinting risks. This may be especially
+              relevant when input methods with distinctive styling characteristics are used.
+            </p>
         </section>
         <section>
             <h3>CharacterBoundsUpdateEvent</h3>

--- a/index.html
+++ b/index.html
@@ -299,10 +299,19 @@
                     the changes back to the page's view so the user can see what they are typing.
                 </li>
                 <li>
-                    The user agent must fire {{TextFormatUpdateEvent}} when the [=Text Input Service=]
-                    indicates that certain formats should be applied to the text being composed. When
-                    the author receives this event, they must render the formatting change back to
-                    the page's view to aid the user with their IME composition.</li>
+                    <p>
+                        The user agent must fire {{TextFormatUpdateEvent}} when the [=Text Input Service=]
+                        indicates that certain formats should be applied to the text being composed. When
+                        the author receives this event, they must render the formatting change back to
+                        the page's view to aid the user with their IME composition.
+                    </p>
+                    <p class="note">
+                        User agents can adjust the {{UnderlineStyle}} or {{UnderlineThickness}} before
+                        dispatching the {{TextFormatUpdateEvent}} to mitigate fingerprinting risks. This may
+                        be especially relevant when input methods with distinctive styling characteristics
+                        are used.
+                    </p>
+                </li>
                 <li>
                     <p>
                         The user agent must fire {{CharacterBoundsUpdateEvent}} when the
@@ -1282,11 +1291,6 @@ interface TextFormatUpdateEvent : Event {
                 <dd>Returns [=this=]'s [=text format list=].</dd>
             </dl>
             <p>A {{TextFormatUpdateEvent}} has an associated <dfn>text format list</dfn>, a list of zero or more [=text format=]s.</p>
-            <p class="note">
-              User agents can adjust the underline style or thickness before dispatching the {{TextFormatUpdateEvent}} 
-              to ensure proper contrast with the content or to mitigate fingerprinting risks. This may be especially
-              relevant when input methods with distinctive styling characteristics are used.
-            </p>
         </section>
         <section>
             <h3>CharacterBoundsUpdateEvent</h3>


### PR DESCRIPTION
Adds a note in `TextFormatUpdateEvent` to mention that UAs can choose to alter the styles before dispatching `textformatupdate` event to combat fingerprinting.

This is not a normative change of behavior, but rather a clarification of flexibility available to UAs

Closes #8

 * [x] For browsers that are shipping the feature, implementation bugs are filed for the proposed changes (link to bug, or write "Not Implementing"):
   * [x] WebKit (https://github.com/WebKit/standards-positions/issues/243)
   * [x] Chromium (https://issues.chromium.org/issues/40642681)
   * [x] Gecko (https://github.com/mozilla/standards-positions/issues/199)
