### PR TITLE
Remove `compositionStart`/`End` from TextUpdateEventInit.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1220,8 +1220,6 @@ interface EditContext : EventTarget {
     DOMString text;
     unsigned long selectionStart;
     unsigned long selectionEnd;
-    unsigned long compositionStart;
-    unsigned long compositionEnd;
 };
 
 [Exposed=Window]


### PR DESCRIPTION
I think these were just accidentally left in by https://github.com/w3c/edit-context/pull/58
