### PR TITLE
Add default values to `*Init` dictionaries

### DIFF
--- a/index.html
+++ b/index.html
@@ -1035,9 +1035,9 @@
         </section>
         <h3 id="editcontext-interface">EditContext Interface</h3>
     <pre class="idl">dictionary EditContextInit {
-    DOMString text;
-    unsigned long selectionStart;
-    unsigned long selectionEnd;
+    DOMString text = "";
+    unsigned long selectionStart = 0;
+    unsigned long selectionEnd = 0;
 };
 
 [Exposed=Window]
@@ -1215,13 +1215,13 @@ interface EditContext : EventTarget {
         <section>
             <h3>TextUpdateEvent</h3>
             <pre class="idl">dictionary TextUpdateEventInit : EventInit {
-    unsigned long updateRangeStart;
-    unsigned long updateRangeEnd;
-    DOMString text;
-    unsigned long selectionStart;
-    unsigned long selectionEnd;
-    unsigned long compositionStart;
-    unsigned long compositionEnd;
+    unsigned long updateRangeStart = 0;
+    unsigned long updateRangeEnd = 0;
+    DOMString text = "";
+    unsigned long selectionStart = 0;
+    unsigned long selectionEnd = 0;
+    unsigned long compositionStart = 0;
+    unsigned long compositionEnd = 0;
 };
 
 [Exposed=Window]
@@ -1256,10 +1256,10 @@ interface TextUpdateEvent : Event {
 enum UnderlineThickness { "none", "thin", "thick" };
 
 dictionary TextFormatInit {
-    unsigned long rangeStart;
-    unsigned long rangeEnd;
-    UnderlineStyle underlineStyle;
-    UnderlineThickness underlineThickness;
+    unsigned long rangeStart = 0;
+    unsigned long rangeEnd = 0;
+    UnderlineStyle underlineStyle = "none";
+    UnderlineThickness underlineThickness = "none";
 };
 
 [Exposed=Window]
@@ -1272,7 +1272,7 @@ interface TextFormat {
 };
 
 dictionary TextFormatUpdateEventInit : EventInit {
-    sequence&lt;TextFormat&gt; textFormats;
+    sequence&lt;TextFormat&gt; textFormats = [];
 };
 
 [Exposed=Window]
@@ -1298,8 +1298,8 @@ interface TextFormatUpdateEvent : Event {
         <section>
             <h3>CharacterBoundsUpdateEvent</h3>
             <pre class="idl">dictionary CharacterBoundsUpdateEventInit : EventInit {
-    unsigned long rangeStart;
-    unsigned long rangeEnd;
+    unsigned long rangeStart = 0;
+    unsigned long rangeEnd = 0;
 };
 
 [Exposed=Window]


### PR DESCRIPTION
The dictionaries for the constructors of EditContext objects are missing default values, so it's unclear what the corresponding attributes should be set to when they aren't passed. These are the defaults which Chrome uses, and they are very much what you would expect.

Closes #124.