### PR TITLE
Turn off `VALIDATE_LINKS` (temporarily?) to fix CI

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -15,7 +15,8 @@ jobs:
       - uses: w3c/spec-prod@v2
         with:
           TOOLCHAIN: respec
-          VALIDATE_LINKS: true
+          # https://github.com/w3c/spec-prod/issues/222
+          # VALIDATE_LINKS: true
           W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
           W3C_WG_DECISION_URL: "https://lists.w3.org/Archives/Public/public-editing-tf/2024Oct/0000.html"
           W3C_NOTIFICATIONS_CC: "${{ secrets.CC }}"


### PR DESCRIPTION
Currently CI is broken because of `link-checker`. See https://github.com/w3c/spec-prod/issues/222