### PR TITLE
Clarify `updateText` behavior when rangeStart > rangeEnd

### DIFF
--- a/index.html
+++ b/index.html
@@ -1098,7 +1098,7 @@ interface EditContext : EventTarget {
                 <ol>
                     <li>
                         Replace the substring of [=text=] in the range of |rangeStart| and |rangeEnd| with |newText|
-                        <div class="note">It's permissible that |rangeStart| > |rangeEnd|. The substring between the indices should be replaced in the same way as when |rangeStart| <= |rangeEnd|.</div>
+                        <div class="note">It's permissible that |rangeStart| > |rangeEnd|. The substring between the indices should be replaced in the same way as if |rangeStart| and |rangeEnd| were swapped.</div>
                     </li>
                 </ol>
             </div>


### PR DESCRIPTION
The wording in the note about what to do for `updateText` when rangeStart > rangeEnd is a bit confusing. I think this should make it a bit clearer :)