### PR TITLE
Specify what TextUpdateEvent updateRangeStart/End should be set to.

### DIFF
--- a/index.html
+++ b/index.html
@@ -853,7 +853,10 @@
                 <li>Set |editContext|'s [=selection end=] to |selectionEnd|.</li>
                 <li>Set |editContext|'s [=composition start=] to |insertionStart|.</li>
                 <li>Set |editContext|'s [=composition end=] to |editContext|'s [=composition start=] plus the length of |text|.</li>
-                <li>[=Dispatch text update event=] given |editContext| and |text|.</li>
+                <li>
+                    [=Dispatch text update event=] given |editContext|, |text|, the minimum of |insertionStart| and |insertionEnd|,
+                    and the maximum of |insertionStart| and |insertionEnd|.
+                </li>
                 <li>
                     If |editContext|'s [=is composing=] is true, then:
                     <ol>
@@ -905,14 +908,18 @@
                 <dt>Input</dt>
                 <dd>|editContext|, an {{EditContext}}</dd>
                 <dd>|text|, a string</dd>
+                <dd>|updateRangeStart|, an offset into |editContext|'s previous {{EditContext/text}}</dd>
+                <dd>|updateRangeEnd|, an offset into |editContext|'s previous {{EditContext/text}}</dd>
                 <dt>Output</dt>
                 <dd>None</dd>
             </dl>
     <ol>
         <li>
             [=Fire an event=] named "textupdate" at |editContext| using {{TextUpdateEvent}}, with
+            {{TextUpdateEvent/updateRangeStart}} initialized to |updateRangeStart|,
+            {{TextUpdateEvent/updateRangeEnd}} initialized to |updateRangeEnd|,
             {{TextUpdateEvent/text}} initialized to |text|,
-            {{TextUpdateEvent/selectionStart}} initialized to ||editContext|'s [=selection start=], and
+            {{TextUpdateEvent/selectionStart}} initialized to |editContext|'s [=selection start=], and
             {{TextUpdateEvent/selectionEnd}} initialized to |editContext|'s [=selection end=].
         </li>
     </ol>


### PR DESCRIPTION
Currently [dispatch-text-update-event](https://w3c.github.io/edit-context/#dispatch-text-update-event) does not specify what the `updateRangeStart` and `updateRangeEnd` attributes should be set to. They should probably be min(insertionStart, insertionEnd) and max(insertionStart, insertionEnd) respectively (this is [what Chrome does](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/editing/ime/edit_context.cc;l=593;drc=c165bab1ca702bf8e7f9539808505a2269deea4b;bpv=0;bpt=1) and what the WPTs expect)