### PR TITLE
Remove beforeinput spec issue note

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,18 +214,6 @@
             <p>
                 A {{Document}} has an <dfn>active EditContext</dfn>, which may be null.
             </p>
-            <p class="issue">
-                The following paragraph can be removed once the behavior change lands
-                in [[input-events]].
-            </p>
-            <p>
-                When an [=EditContext editing host=] receives text input from the
-                [=Text Input Service=], as the
-                <a href="https://www.w3.org/TR/uievents/#default-action">default action</a> for the
-                <a href="https://www.w3.org/TR/uievents/#event-type-beforeinput">beforeinput</a>
-                event fired as a result of that input the user agent must run
-                [=Handle Input for EditContext=] given the [=EditContext editing host=] .
-            </p>
             <h4 id="edit-context-differences">Differences for an EditContext editing host</h4>
             <div>
                 <p>


### PR DESCRIPTION
Remove the provisional beforeinput paragraph and its associated spec issue note from the EditContext spec. The change describing the beforeinput default action for an EditContext editing host has landed in [Input Events Level 2](https://www.w3.org/TR/input-events-2/#event-type-beforeinput), so the inline definition and the tracking issue note are no longer needed.

> This is an editorial change, it just removes a redundant normative statement and its tracking issue note