### PR TITLE
Add TextFormat.textColor and TextFormat.backgroundColor.

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,6 +124,12 @@
                 <li><dfn>range end</dfn> which is an offset into [=text=] that respresents the position after the last codepoint that should be decorated.</li>
                 <li><dfn>underline style</dfn>, a {{UnderlineStyle}} which is the preferred underline style of the decorated [=text=] range.</li>
                 <li><dfn>underline thickness</dfn>, a {{UnderlineThickness}} which is the preferred underline thickness of the decorated [=text=] range.</li>
+                <li><dfn>text color</dfn>, an empty string or <a href="https://www.w3.org/TR/css-color-4/#css-serialization-of-srgb"
+                    >a CSS serialization of sRGB values</a>,
+                    indicating the preferred text color of the decorated [=text=] range.</li>
+                <li><dfn>background color</dfn>, an empty string or <a href="https://www.w3.org/TR/css-color-4/#css-serialization-of-srgb"
+                    >a CSS serialization of sRGB values</a>,
+                    indicating the preferred background color of the decorated [=text=] range.</li>
             </ul>
             <p class="note">
               [=Codepoint rects=] provides the means for the user agent to query a range of
@@ -927,6 +933,8 @@
             <li>Set |textFormat|'s {{TextFormat/rangeEnd}} to |format|'s [=range end=].</li>
             <li>Set |textFormat|'s {{TextFormat/underlineStyle}} to |format|'s [=underline style=].</li>
             <li>Set |textFormat|'s {{TextFormat/underlineThickness}} to |format|'s [=underline thickness=].</li>
+            <li>Set |textFormat|'s {{TextFormat/textColor}} to |format|'s [=text color=].</li>
+            <li>Set |textFormat|'s {{TextFormat/backgroundColor}} to |format|'s [=background color=].</li>
             <li>Append |textFormat| to |formats|</li>
         </ol>
     </li>
@@ -1250,6 +1258,8 @@ dictionary TextFormatInit {
     unsigned long rangeEnd = 0;
     UnderlineStyle underlineStyle = "none";
     UnderlineThickness underlineThickness = "none";
+    DOMString textColor = "";
+    DOMString backgroundColor = "";
 };
 
 [Exposed=Window]
@@ -1259,6 +1269,8 @@ interface TextFormat {
     readonly attribute unsigned long rangeEnd;
     readonly attribute UnderlineStyle underlineStyle;
     readonly attribute UnderlineThickness underlineThickness;
+    readonly attribute DOMString textColor;
+    readonly attribute DOMString backgroundColor;
 };
 
 dictionary TextFormatUpdateEventInit : EventInit {
@@ -1279,6 +1291,14 @@ interface TextFormatUpdateEvent : Event {
                 <dd>The preferred underline style of the decorated text range.</dd>
                 <dt>{{TextFormat/underlineThickness}}, of type {{UnderlineThickness}}, readonly</dt>
                 <dd> The preferred underline thickness of the decorated text range.</dd>
+                <dt>{{TextFormat/textColor}}, of type {{DOMString}}, readonly</dt>
+                <dd>The preferred text color of the decorated text range represented as
+                    <a href="https://www.w3.org/TR/css-color-4/#css-serialization-of-srgb">a CSS serialization of sRGB values</a>,
+                    or an empty string to indicate no preferred text color.</dd>
+                <dt>{{TextFormat/backgroundColor}}, of type {{DOMString}}, readonly</dt>
+                <dd>The preferred background color of the decorated text range represented as
+                    <a href="https://www.w3.org/TR/css-color-4/#css-serialization-of-srgb">a CSS serialization of sRGB values</a>,
+                    or an empty string to indicate no preferred background color.</dd>
                 <dt>{{TextFormatUpdateEvent/getTextFormats}} method
                 </dt>
                 <dd>Returns [=this=]'s [=text format list=].</dd>


### PR DESCRIPTION
Fixes #54.

Based on the IMEs I've tried out, I don't think there's any need to add a separate `underlineColor` (like there was before) - the underline can just be colored with the `textColor`.

For normative changes, the following tasks have been completed:
 * [ ] Editing WG resolution on the proposed changes, with at least two implementers participating and not objecting:
   * [ ] WebKit
   * [ ] Chromium
   * [X] Gecko

 * [ ] For browsers that are shipping the feature, implementation bugs are filed for the proposed changes (link to bug, or write "Not Implementing"):
   * [X] WebKit - Not Implementing
   * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
   * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)
