### PR TITLE
Dispatch textformatupdate with empty format list when deactivating EditContext

### DIFF
--- a/index.html
+++ b/index.html
@@ -967,6 +967,10 @@
             <ol>
                 <li>Set |editContext|'s [=is composing=] to false.</li>
                 <li>
+                    [=Fire an event=] named "textformatupdate" at |editContext| using {{TextFormatUpdateEvent}} with
+                    the {{TextFormatUpdateEvent}}'s [=text format list=] initialized to an empty list.
+                </li>
+                <li>
                     [=Fire an event=] named
                     <a href="https://w3c.github.io/uievents/#event-type-compositionend">compositionend</a>
                     at |editContext| using {{CompositionEvent}}.


### PR DESCRIPTION
Fixes #138.

For normative changes, the following tasks have been completed:
 * [ ] Editing WG resolution on the proposed changes, with at least two implementers participating and not objecting:
   * [ ] WebKit
   * [ ] Chromium
   * [X] Gecko

 * [ ] For browsers that are shipping the feature, implementation bugs are filed for the proposed changes (link to bug, or write "Not Implementing"):
   * [x] WebKit - Not Implementing
   * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
   * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)
